### PR TITLE
Add support for staging component name mywolfssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,41 @@
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+set(WOLFSSL_COMPONENT_NAME "wolfssl")
 
+# Optional Staging instance use of wolfssl, the component is called "mywolfssl"
+if( "$ENV{IDF_COMPONENT_REGISTRY_URL}" STREQUAL "https://components-staging.espressif.com" )
+    # When set to a specific value, IDF_COMPONENT_REGISTRY_URL indicates the component is used for testing / preview
+    if(  ( NOT ("${managed_components}"                  STREQUAL ""  )) OR
+         ( NOT ("${component_manager_interface_version}" STREQUAL ""  )) OR
+         (     ("${IDF_COMPONENT_MANAGER}"               STREQUAL "1" ))    )
+        # Alternate naming for staging component
+        message(STATUS "*********************************************************************************")
+        message(STATUS "*********************************************************************************")
+        message(STATUS "*                                                                               *")
+        message(STATUS "*        NOTICE: Using wolfSSL preview test library called mywolfssl from       *")
+        message(STATUS "*                                                                               *")
+        message(STATUS "*     IDF_COMPONENT_REGISTRY_URL  =  https://components-staging.espressif.com   *")
+        message(STATUS "*                                                                               *")
+        message(STATUS "*********************************************************************************")
+        message(STATUS "*********************************************************************************")
+        set(WOLFSSL_COMPONENT_NAME "mywolfssl")
+    else()
+        # Detected IDF_COMPONENT_REGISTRY_URL as staging, but could not confirm component manager
+        message(STATUS "*********************************************************************************")
+        message(STATUS "*********************************************************************************")
+        message(STATUS "*                                                                               *")
+        message(STATUS "* WARNING: could not detect component manager, using wolfSSL component wolfssl  *")
+        message(STATUS "*                                                                               *")
+        message(STATUS "*     IDF_COMPONENT_REGISTRY_URL =   https://components-staging.espressif.com   *")
+        message(STATUS "*                                                                               *")
+        message(STATUS "*********************************************************************************")
+        message(STATUS "*********************************************************************************")
+        set(WOLFSSL_COMPONENT_NAME "wolfssl")
+    endif()
+else()
+    set(WOLFSSL_COMPONENT_NAME "wolfssl")
+endif()
+
+message(STATUS "WOLFSSL_COMPONENT_NAME= ${WOLFSSL_COMPONENT_NAME}")
 idf_component_register(
     SRC_DIRS src
     EXCLUDE_SRCS
@@ -7,7 +43,7 @@ idf_component_register(
         "src/homekit_mdns_debug.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "src"
-    REQUIRES wolfssl esp_partition json http-parser mdns spi_flash
+    REQUIRES esp_partition json http-parser mdns spi_flash "${WOLFSSL_COMPONENT_NAME}"
 )
 
 #if(CONFIG_HOMEKIT_SMALL)


### PR DESCRIPTION
The staging instance component name of wolfSSL is called `mywolfssl` instead of `wolfssl` to ensure there's no ambiguity between release and test/ preview code.

https://components-staging.espressif.com/components/gojimmypi/mywolfssl