### PR TITLE
Fix base64 decoded size calculation

### DIFF
--- a/dist/esp32-homekit_1.0.0/src/base64.c
+++ b/dist/esp32-homekit_1.0.0/src/base64.c
@@ -28,10 +28,13 @@ size_t base64_encoded_size(const unsigned char *data, size_t size) {
 }
 
 size_t base64_decoded_size(const unsigned char *encoded_data, size_t encoded_size) {
-        size_t size = (encoded_size + 3)/4*3;
-        if (encoded_data[encoded_size-1] == '=')
+        if (encoded_size == 0)
+                return 0;
+
+        size_t size = (encoded_size + 3) / 4 * 3;
+        if (encoded_size > 0 && encoded_data[encoded_size - 1] == '=')
                 size--;
-        if (encoded_data[encoded_size-2] == '=')
+        if (encoded_size > 1 && encoded_data[encoded_size - 2] == '=')
                 size--;
         return size;
 }

--- a/dist/esp32-homekit_1.2.0/src/base64.c
+++ b/dist/esp32-homekit_1.2.0/src/base64.c
@@ -28,10 +28,13 @@ size_t base64_encoded_size(const unsigned char *data, size_t size) {
 }
 
 size_t base64_decoded_size(const unsigned char *encoded_data, size_t encoded_size) {
-        size_t size = (encoded_size + 3)/4*3;
-        if (encoded_data[encoded_size-1] == '=')
+        if (encoded_size == 0)
+                return 0;
+
+        size_t size = (encoded_size + 3) / 4 * 3;
+        if (encoded_size > 0 && encoded_data[encoded_size - 1] == '=')
                 size--;
-        if (encoded_data[encoded_size-2] == '=')
+        if (encoded_size > 1 && encoded_data[encoded_size - 2] == '=')
                 size--;
         return size;
 }

--- a/dist/esp32-homekit_1.2.1/src/base64.c
+++ b/dist/esp32-homekit_1.2.1/src/base64.c
@@ -28,10 +28,13 @@ size_t base64_encoded_size(const unsigned char *data, size_t size) {
 }
 
 size_t base64_decoded_size(const unsigned char *encoded_data, size_t encoded_size) {
-        size_t size = (encoded_size + 3)/4*3;
-        if (encoded_data[encoded_size-1] == '=')
+        if (encoded_size == 0)
+                return 0;
+
+        size_t size = (encoded_size + 3) / 4 * 3;
+        if (encoded_size > 0 && encoded_data[encoded_size - 1] == '=')
                 size--;
-        if (encoded_data[encoded_size-2] == '=')
+        if (encoded_size > 1 && encoded_data[encoded_size - 2] == '=')
                 size--;
         return size;
 }

--- a/src/base64.c
+++ b/src/base64.c
@@ -28,10 +28,13 @@ size_t base64_encoded_size(const unsigned char *data, size_t size) {
 }
 
 size_t base64_decoded_size(const unsigned char *encoded_data, size_t encoded_size) {
-        size_t size = (encoded_size + 3)/4*3;
-        if (encoded_data[encoded_size-1] == '=')
+        if (encoded_size == 0)
+                return 0;
+
+        size_t size = (encoded_size + 3) / 4 * 3;
+        if (encoded_size > 0 && encoded_data[encoded_size - 1] == '=')
                 size--;
-        if (encoded_data[encoded_size-2] == '=')
+        if (encoded_size > 1 && encoded_data[encoded_size - 2] == '=')
                 size--;
         return size;
 }


### PR DESCRIPTION
## Summary
- guard against short base64 strings when computing decoded length

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684039f0aad883218f32db23ae0ee83e