### PR TITLE
Update wolfssl and mdns versions

### DIFF
--- a/examples/led/README.md
+++ b/examples/led/README.md
@@ -19,8 +19,8 @@ Connect `LED` pin to the following pin:
 ## Requirements
 
 - **idf version:** `>=5.0`
-- **espressif/mdns version:** `1.8.0`
-- **wolfssl/wolfssl version:** `5.7.6`
+- **espressif/mdns version:** `1.8.2`
+- **wolfssl/wolfssl version:** `5.8.0`
 - **achimpieters/esp32-homekit version:** `1.0.0`
 
 ## Notes

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -11,9 +11,9 @@ dependencies:
   idf:
     version: ">=5.0"
   espressif/mdns:
-    version: "1.8.0"
+    version: "1.8.2"
   wolfssl/wolfssl:
-    version: "5.7.6"
+    version: "5.8.0"
 targets:
   - "esp32"
   - "esp32c2"


### PR DESCRIPTION
## Summary
- bump wolfssl to 5.8.0
- bump mdns to 1.8.2

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6843ddc606b88321baa17b295b71862a