### PR TITLE
Fix wolfSSL include paths and settings for managed build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ idf_component_register(
         "src/homekit_mdns_debug.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "src"
-    REQUIRES wolfssl esp_partition json http_parser spi_flash nvs_flash
+    REQUIRES wolfssl__wolfssl esp_partition json http_parser spi_flash nvs_flash
 )
 
 #if(CONFIG_HOMEKIT_SMALL)

--- a/managed_components/wolfssl__wolfssl/include/user_settings.h
+++ b/managed_components/wolfssl__wolfssl/include/user_settings.h
@@ -1,0 +1,37 @@
+/*
+ * Local wolfSSL user settings guard file.
+ * Ensures configuration macros are only defined when missing to avoid
+ * redefinition warnings when the build system also supplies them.
+ */
+
+#ifndef WOLFCRYPT_HAVE_SRP
+#define WOLFCRYPT_HAVE_SRP
+#endif
+
+#ifndef HAVE_CHACHA
+#define HAVE_CHACHA
+#endif
+
+#ifndef HAVE_POLY1305
+#define HAVE_POLY1305
+#endif
+
+#ifndef WOLFSSL_BASE64_ENCODE
+#define WOLFSSL_BASE64_ENCODE
+#endif
+
+#ifndef NO_SESSION_CACHE
+#define NO_SESSION_CACHE
+#endif
+
+#ifndef RSA_LOW_MEM
+#define RSA_LOW_MEM
+#endif
+
+#ifndef HAVE_HKDF
+#define HAVE_HKDF
+#endif
+
+#ifndef WOLFSSL_SHA512
+#define WOLFSSL_SHA512
+#endif

--- a/sdkconfig
+++ b/sdkconfig
@@ -1,0 +1,2 @@
+# Default SDK configuration adjusted for managed wolfSSL component path
+CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT="/project/managed_components/wolfssl__wolfssl"

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -3,7 +3,7 @@
 
 #include <stdlib.h>
 
-#include <wolfssl/options.h>
+#include "wolfssl/options.h"
 
 // Ensure the required WolfSSL features are enabled even when build flags are
 // missed by the component manager.


### PR DESCRIPTION
## Summary
- adjust wolfSSL options include and component dependency to match managed component paths
- add guarded wolfSSL user_settings.h to avoid macro redefinition warnings during builds
- document the correct wolfSSL root location in sdkconfig to prevent stale path usage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932a67d95f8832191277190cf1358a7)