### PR TITLE
Handle managed wolfSSL options include

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -3,7 +3,11 @@
 
 #include <stdlib.h>
 
-#include "wolfssl/options.h"
+// options.h is not present in the IDF-managed wolfSSL component and all
+// options are configured via user_settings.h/settings.h instead.
+// #include "wolfssl/options.h"
+
+#include <wolfssl/wolfcrypt/settings.h>
 
 // Ensure the required WolfSSL features are enabled even when build flags are
 // missed by the component manager.


### PR DESCRIPTION
## Summary
- comment out inclusion of the unavailable `wolfssl/options.h` when using the managed wolfSSL component
- include `wolfssl/wolfcrypt/settings.h` explicitly with clarifying notes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ad2bd67c8321a5b98453989b1757)