### PR TITLE
Include wc_port for RNG seed callback

### DIFF
--- a/dist/esp32-homekit_1.3.1/src/crypto.c
+++ b/dist/esp32-homekit_1.3.1/src/crypto.c
@@ -13,6 +13,7 @@
 #include <wolfssl/wolfcrypt/srp.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/wc_port.h>
 
 #include "port.h"
 #include "debug.h"

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -13,6 +13,7 @@
 #include <wolfssl/wolfcrypt/srp.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/wc_port.h>
 
 #include "port.h"
 #include "debug.h"


### PR DESCRIPTION
## Summary
- include wolfSSL wc_port header so wc_SetSeed_Cb prototype is available
- apply the same change to the distributed source copy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932cdc3a5488321861c67168a4b484e)