### PR TITLE
Fix LED example dependency namespace for local esp32-homekit component

### DIFF
--- a/examples/led/main/idf_component.yml
+++ b/examples/led/main/idf_component.yml
@@ -1,5 +1,5 @@
 dependencies:
   idf:
     version: ">=5.0"
-  esp32-homekit:
+  achimpieters/esp32-homekit:
     path: ../../..


### PR DESCRIPTION
### Motivation
- The LED example failed to resolve the local component because the dependency key did not match the registry namespaced key, causing a "unknown name" error during dependency resolution.

### Description
- Update `examples/led/main/idf_component.yml` to replace `esp32-homekit` with `achimpieters/esp32-homekit` while preserving the local override `path: ../../..`.

### Testing
- Ran `idf.py set-target esp32` in `examples/led` and confirmed the local component is now recognized as `achimpieters/esp32-homekit`, which removes the previous "Failed to resolve component 'esp32-homekit' ... unknown name" error; the configuration later stops due to inability to reach the Espressif component registry for `espressif/mdns` (network/registry issue, unrelated to this fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b20513208321a9b6bad916019e2b)