### PR TITLE
Fix LED example dependency resolution by removing COMPONENTS override

### DIFF
--- a/examples/led/CMakeLists.txt
+++ b/examples/led/CMakeLists.txt
@@ -31,7 +31,5 @@ elseif(CONFIG_IDF_TARGET STREQUAL "esp32c5")
 endif()
 message(STATUS "Partition table file: ${PARTITION_TABLE_DEFAULT}")
 
-set(COMPONENTS main)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(main)


### PR DESCRIPTION
### Motivation
- The LED example forced a `main`-only component list which prevented ESP-IDF from including managed dependencies and caused component-resolution failures for the local `achimpieters/esp32-homekit` dependency.

### Description
- Removed the explicit `set(COMPONENTS main)` line from `examples/led/CMakeLists.txt` so the ESP-IDF component manager can include managed dependencies.

### Testing
- Ran `idf.py reconfigure` in `examples/led` which progressed past the previous `unknown name` component-resolution error but the run later failed due to inability to reach the ESP-IDF component registry (`https://components-file.espressif.com/components/espressif/mdns.json`) in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d0c6dcc48321bcd15a9ddf54c744)