### PR TITLE
fix: correct local dependency key for led example component

### DIFF
--- a/examples/led/main/idf_component.yml
+++ b/examples/led/main/idf_component.yml
@@ -1,5 +1,5 @@
 dependencies:
   idf:
     version: ">=5.0"
-  achimpieters/esp32-homekit:
+  esp32-homekit:
     path: ../../..


### PR DESCRIPTION
### Motivation
- The LED example used a namespaced dependency key (`achimpieters/esp32-homekit`) which led CMake to look for a generated alias (`achimpieters__esp32-homekit`) that cannot be resolved for a local-path dependency, causing configure to fail.

### Description
- Update `examples/led/main/idf_component.yml` to use the local component name key `esp32-homekit` with the same `path: ../../..` so the component is resolved from the local tree.

### Testing
- Verified the manifest file contents (`nl -ba examples/led/main/idf_component.yml`) reflect the change; attempted to reproduce an `idf.py` configure/build in a container but Docker/ESP-IDF toolchain is not available in this environment so full build could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d1da4f3c8321ac797f5181addf24)