### PR TITLE
fix: correct LED example component dependency name

### DIFF
--- a/examples/led/main/idf_component.yml
+++ b/examples/led/main/idf_component.yml
@@ -1,5 +1,5 @@
 dependencies:
   idf:
     version: ">=5.0"
-  esp32_homekit:
+  achimpieters/esp32-homekit:
     path: ../../..


### PR DESCRIPTION
### Motivation
- Fix ESP-IDF component resolution failure when building the LED example by using the canonical component name expected by the IDF component manager instead of an unknown short name.

### Description
- Update `examples/led/main/idf_component.yml` to replace `esp32_homekit:` with `achimpieters/esp32-homekit:` while keeping the existing `path: ../../..`.

### Testing
- Ran `git diff --check` and inspected `examples/led/main/idf_component.yml` to confirm the `esp32_homekit` reference was removed and replaced with `achimpieters/esp32-homekit`, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d46845b88321af3ef470ef368b72)