### PR TITLE
fix(led-example): use local component name in dependency

### DIFF
--- a/examples/led/main/idf_component.yml
+++ b/examples/led/main/idf_component.yml
@@ -1,5 +1,5 @@
 dependencies:
   idf:
     version: ">=5.0"
-  achimpieters/esp32-homekit:
+  esp32-homekit:
     path: ../../..


### PR DESCRIPTION
### Motivation
- Fix a CMake dependency resolution failure where the LED example referenced the project by the remote name while using a local `path` dependency, causing an unknown component name error.

### Description
- Update `examples/led/main/idf_component.yml` to change the dependency key from `achimpieters/esp32-homekit` to `esp32-homekit` so it matches the root component `name` in `idf_component.yml`.

### Testing
- Ran `idf.py set-target esp32` in `examples/led`, which now reports `Using component placed at /workspace/esp32-homekit for dependency "esp32-homekit"` indicating the local component is recognized, and the run later stopped due to inability to contact the Espressif component registry in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d5b48f808321947c0e51e83e9e1c)