### PR TITLE
Use repository-local esp32-homekit dependency in LED example

### DIFF
--- a/examples/led/README.md
+++ b/examples/led/README.md
@@ -21,7 +21,7 @@ Connect `LED` pin to the following pin:
 - **idf version:** `>=5.0`
 - **espressif/mdns version:** `1.8.2`
 - **wolfssl/wolfssl version:** `5.8.0`
-- **achimpieters/esp32-homekit version:** `1.0.0`
+- **esp32-homekit:** gebruikt de lokale repository via `path: ../../..` in `main/idf_component.yml`.
 
 ## Notes
 

--- a/examples/led/main/idf_component.yml
+++ b/examples/led/main/idf_component.yml
@@ -1,5 +1,5 @@
 dependencies:
   idf:
     version: ">=5.0"
-  achimpieters/esp32-homekit:
+  esp32-homekit:
     path: ../../..


### PR DESCRIPTION
### Motivation
- Ensure the LED example uses the repository-local component instead of the remote package name so the example builds against the current workspace copy of the library.

### Description
- Updated `examples/led/main/idf_component.yml` to declare the dependency as `esp32-homekit` with `path: ../../..` and updated `examples/led/README.md` to document that the example uses the local repository via that path.

### Testing
- Ran `git diff --check` and reviewed the `git diff` for `examples/led/main/idf_component.yml` and `examples/led/README.md`, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991dba10ffc8321a44a225126482d73)