### PR TITLE
Add missing HAP accessory category enums and document remaining protocol gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+- Added missing HAP accessory categories for HomePod (25), Router (33), Audio Receiver (34), TV Set-Top Box (35), and TV Streaming Stick (36).
+- Updated README HomeKit category reference table to include the above categories.
+
 ## [1.3.8] - 2026-15-02
 - Remove GCC pragma for override-init warnings
 - Updated espressif/mdns to 1.9.1

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ tools/gen_qrcode 5 123-45-678 1QJ8 qrcode.png
 | Humidifiers        | 22     |
 | Dehumidifiers      | 23     |
 | Apple TV           | 24     |
+| HomePod            | 25     |
 | Speakers           | 26     |
 | Airport            | 27     |
 | Sprinklers         | 28     |
@@ -169,6 +170,10 @@ tools/gen_qrcode 5 123-45-678 1QJ8 qrcode.png
 | Shower heads       | 30     |
 | Televisions        | 31     |
 | Target remotes     | 32     |
+| Routers            | 33     |
+| Audio receivers    | 34     |
+| TV set-top boxes   | 35     |
+| TV streaming sticks| 36     |
 
 For the full list, refer to the official HomeKit documentation.
 

--- a/include/homekit/types.h
+++ b/include/homekit/types.h
@@ -62,6 +62,7 @@ typedef enum {
         homekit_accessory_category_humidifier = 22,
         homekit_accessory_category_dehumidifier = 23,
         homekit_accessory_category_apple_tv = 24,
+        homekit_accessory_category_homepod = 25,
         homekit_accessory_category_speakers = 26,
         homekit_accessory_category_airport = 27,
         homekit_accessory_category_sprinklers = 28,
@@ -69,6 +70,10 @@ typedef enum {
         homekit_accessory_category_shower_heads = 30,
         homekit_accessory_category_televisions = 31,
         homekit_accessory_category_target_remotes = 32,
+        homekit_accessory_category_routers = 33,
+        homekit_accessory_category_audio_receivers = 34,
+        homekit_accessory_category_tv_set_top_boxes = 35,
+        homekit_accessory_category_tv_streaming_sticks = 36,
 } homekit_accessory_category_t;
 
 struct _homekit_accessory;


### PR DESCRIPTION
### Motivation
- Ensure the codebase recognises newly defined HomeKit accessory categories from modern HAP references so accessory `category` fields can represent HomePod and newer TV/network/audio device types. 
- Provide minimal, low-risk compatibility fix that is fully additive and does not change existing enum values.
- Record the audit findings so follow-up work to bring full HAP parity is planned and visible.

### Description
- Added new accessory categories to `homekit_accessory_category_t` in `include/homekit/types.h`: `homekit_accessory_category_homepod = 25`, `homekit_accessory_category_routers = 33`, `homekit_accessory_category_audio_receivers = 34`, `homekit_accessory_category_tv_set_top_boxes = 35`, and `homekit_accessory_category_tv_streaming_sticks = 36`.
- Updated the HomeKit accessory category table in `README.md` to include the new category entries (25, 33–36).
- Prepended an `Unreleased` entry in `CHANGELOG.md` documenting the added categories and README update.
- Captured audit summary indicating the repository is not fully up to date with the latest HAP service/characteristic UUID surface and therefore further staged updates are recommended.

### Testing
- Performed a protocol-surface comparison against `homebridge/HAP-NodeJS` generated HAP definitions using small Python/`curl` scripts and confirmed a difference of `Service UUIDs local=42 latest_ref=72 missing=30` and `Characteristic UUIDs local=136 latest_ref=249 missing=113`, which validates that only categories were updated in this patch and larger coverage is still required. 
- Ran targeted repository scans to verify presence of category identifiers and service/characteristic macros in `include/homekit/characteristics.h` and `include/homekit/types.h` and confirmed the new enum values are present and consistent with README. 
- Performed a repository consistency/check pass (`diff --check` style verification) to ensure no whitespace or syntactic issues were introduced and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ffbfe35c8321b4a419f99cb9aca6)