### PR TITLE
Fix LED example accessory category and HOMEKIT_ACCESSORY macro defaults

### DIFF
--- a/examples/led/main/main.c
+++ b/examples/led/main/main.c
@@ -151,10 +151,8 @@ homekit_characteristic_t serial = HOMEKIT_CHARACTERISTIC_(SERIAL_NUMBER, DEVICE_
 homekit_characteristic_t model = HOMEKIT_CHARACTERISTIC_(MODEL, DEVICE_MODEL);
 homekit_characteristic_t revision = HOMEKIT_CHARACTERISTIC_(FIRMWARE_REVISION, FW_VERSION);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverride-init"
 homekit_accessory_t *accessories[] = {
-        HOMEKIT_ACCESSORY(.id = 1, .category = homekit_accessory_category_lighting, .services = (homekit_service_t*[]) {
+        HOMEKIT_ACCESSORY(.id = 1, .category = homekit_accessory_category_light, .services = (homekit_service_t*[]) {
                 HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics = (homekit_characteristic_t*[]) {
                         &name,
                         &manufacturer,
@@ -173,7 +171,6 @@ homekit_accessory_t *accessories[] = {
         }),
         NULL
 };
-#pragma GCC diagnostic pop
 
 homekit_server_config_t config = {
         .accessories = accessories,

--- a/include/homekit/types.h
+++ b/include/homekit/types.h
@@ -244,8 +244,6 @@ void homekit_characteristic_default_setter_ex(homekit_characteristic_t *ch, home
 // Macro to define accessory
 #define HOMEKIT_ACCESSORY(...) \
         & (homekit_accessory_t) { \
-                .config_number=1, \
-                .category=homekit_accessory_category_other, \
                 ##__VA_ARGS__ \
         }
 


### PR DESCRIPTION
### Motivation

- The LED example used an incorrect accessory category and relied on diagnostic pragmas to silence initialization warnings, and the accessory macro injected implicit defaults that could mask required fields.

### Description

- Change the LED example accessory category from `homekit_accessory_category_lighting` to `homekit_accessory_category_light` in `examples/led/main/main.c`.
- Remove the surrounding `#pragma GCC diagnostic push/ignored/ pop` lines in the LED example since they are no longer required.
- Update the `HOMEKIT_ACCESSORY` macro in `include/homekit/types.h` to stop injecting default `.config_number` and `.category` initializers so callers explicitly control those fields.
- The changes affect `examples/led/main/main.c` and `include/homekit/types.h`.

### Testing

- Ran `git diff --check` to ensure the patch contains no whitespace or diff errors and it succeeded.
- Verified the working tree is clean via `git status --short` after applying the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930b756af8832184fe0e3e5bb250e2)