### PR TITLE
homekit: add HOMEKIT_ACCESSORY_WITH_CATEGORY to avoid -Woverride-init

### DIFF
--- a/examples/led/main/main.c
+++ b/examples/led/main/main.c
@@ -151,10 +151,8 @@ homekit_characteristic_t serial = HOMEKIT_CHARACTERISTIC_(SERIAL_NUMBER, DEVICE_
 homekit_characteristic_t model = HOMEKIT_CHARACTERISTIC_(MODEL, DEVICE_MODEL);
 homekit_characteristic_t revision = HOMEKIT_CHARACTERISTIC_(FIRMWARE_REVISION, FW_VERSION);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverride-init"
 homekit_accessory_t *accessories[] = {
-        HOMEKIT_ACCESSORY(.id = 1, .category = homekit_accessory_category_lighting, .services = (homekit_service_t*[]) {
+        HOMEKIT_ACCESSORY_WITH_CATEGORY(homekit_accessory_category_lighting, .id = 1, .services = (homekit_service_t*[]) {
                 HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics = (homekit_characteristic_t*[]) {
                         &name,
                         &manufacturer,
@@ -173,7 +171,6 @@ homekit_accessory_t *accessories[] = {
         }),
         NULL
 };
-#pragma GCC diagnostic pop
 
 homekit_server_config_t config = {
         .accessories = accessories,

--- a/include/homekit/types.h
+++ b/include/homekit/types.h
@@ -249,6 +249,15 @@ void homekit_characteristic_default_setter_ex(homekit_characteristic_t *ch, home
                 ##__VA_ARGS__ \
         }
 
+// Macro to define accessory with explicit category and default config number.
+// This avoids override-init warnings when setting category in strict builds.
+#define HOMEKIT_ACCESSORY_WITH_CATEGORY(_category, ...) \
+        & (homekit_accessory_t) { \
+                .config_number=1, \
+                .category=_category, \
+                ##__VA_ARGS__ \
+        }
+
 // Macro to define service inside accessory definition.
 // Requires HOMEKIT_SERVICE_<name> define to expand to service type UUID string
 #define HOMEKIT_SERVICE(_type, ...) \


### PR DESCRIPTION
### Motivation
- Remove the need for `#pragma GCC diagnostic` suppression by avoiding duplicate designated initialization of `.category` which triggers `-Woverride-init` warnings. 
- Keep example code clean and compatible with stricter compiler warning settings while preserving default accessory behavior.

### Description
- Added `HOMEKIT_ACCESSORY_WITH_CATEGORY(_category, ...)` to `include/homekit/types.h` which sets `.config_number=1` and accepts an explicit `.category` without causing override-init overrides. 
- Updated `examples/led/main/main.c` to use `HOMEKIT_ACCESSORY_WITH_CATEGORY(homekit_accessory_category_lighting, ...)` instead of overriding `.category` on top of the existing `HOMEKIT_ACCESSORY` macro. 
- Preserved existing default behavior for `config_number` while enabling explicit category assignment in examples.

### Testing
- Ran `rg -n "#pragma GCC diagnostic|override-init|HOMEKIT_ACCESSORY_WITH_CATEGORY"` to confirm the example no longer contains pragma suppression and the new macro is present, and the check succeeded. 
- Inspected the modified context with `nl -ba` to confirm the new macro definition in `include/homekit/types.h` and its usage in `examples/led/main/main.c`, and the inspection matched expectations. 
- Verified the working tree shows the intended file modifications with `git status --short`, and the verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69931426ee808321aa62a4137733eaab)