### PR TITLE
Avoid -Woverride-init diagnostics in HOMEKIT_ACCESSORY macro

### DIFF
--- a/examples/led/main/main.c
+++ b/examples/led/main/main.c
@@ -151,8 +151,6 @@ homekit_characteristic_t serial = HOMEKIT_CHARACTERISTIC_(SERIAL_NUMBER, DEVICE_
 homekit_characteristic_t model = HOMEKIT_CHARACTERISTIC_(MODEL, DEVICE_MODEL);
 homekit_characteristic_t revision = HOMEKIT_CHARACTERISTIC_(FIRMWARE_REVISION, FW_VERSION);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverride-init"
 homekit_accessory_t *accessories[] = {
         HOMEKIT_ACCESSORY(.id = 1, .category = homekit_accessory_category_lighting, .services = (homekit_service_t*[]) {
                 HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics = (homekit_characteristic_t*[]) {
@@ -173,7 +171,6 @@ homekit_accessory_t *accessories[] = {
         }),
         NULL
 };
-#pragma GCC diagnostic pop
 
 homekit_server_config_t config = {
         .accessories = accessories,

--- a/include/homekit/types.h
+++ b/include/homekit/types.h
@@ -246,13 +246,21 @@ struct _homekit_accessory {
 homekit_value_t homekit_characteristic_default_getter_ex(const homekit_characteristic_t *ch);
 void homekit_characteristic_default_setter_ex(homekit_characteristic_t *ch, homekit_value_t value);
 
+static inline homekit_accessory_t *homekit_accessory_default(homekit_accessory_t *accessory) {
+        if (!accessory->config_number) {
+                accessory->config_number = 1;
+        }
+        if (!accessory->category) {
+                accessory->category = homekit_accessory_category_other;
+        }
+        return accessory;
+}
+
 // Macro to define accessory
 #define HOMEKIT_ACCESSORY(...) \
-        & (homekit_accessory_t) { \
-                .config_number=1, \
-                .category=homekit_accessory_category_other, \
+        homekit_accessory_default(&(homekit_accessory_t) { \
                 ##__VA_ARGS__ \
-        }
+        })
 
 // Macro to define service inside accessory definition.
 // Requires HOMEKIT_SERVICE_<name> define to expand to service type UUID string


### PR DESCRIPTION
### Motivation
- The `HOMEKIT_ACCESSORY` macro previously pre-filled `.config_number` and `.category`, which led to duplicate designated initializer warnings under `-Woverride-init` when callers set those fields. 
- The goal is to remove the need for local `#pragma GCC diagnostic ignored "-Woverride-init"` workarounds in example code while preserving the existing defaults. 

### Description
- Added a helper `static inline homekit_accessory_t *homekit_accessory_default(homekit_accessory_t *accessory)` in `include/homekit/types.h` that sets `config_number` and `category` only when they are not provided by the caller. 
- Rewrote the `HOMEKIT_ACCESSORY` macro in `include/homekit/types.h` to wrap the compound literal with `homekit_accessory_default(...)` instead of hardcoding default fields in the literal. 
- Removed the `#pragma GCC diagnostic push/ignored "-Woverride-init"/pop` lines from `examples/led/main/main.c` since they are no longer required. 

### Testing
- Inspected diffs with `git diff` to confirm `include/homekit/types.h` and `examples/led/main/main.c` were updated as intended and the pragma lines were removed, which succeeded. 
- Searched the tree with `rg` to verify the new `homekit_accessory_default(` symbol exists and `-Woverride-init` pragma occurrences were eliminated, which succeeded. 
- Ran `git status` and committed the changes to record the modification, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69931a6c89bc83218664617abfce3b6b)