### PR TITLE
Fix HOMEKIT_ACCESSORY macro expansion with designated initializers

### DIFF
--- a/include/homekit/types.h
+++ b/include/homekit/types.h
@@ -259,7 +259,7 @@ static inline homekit_accessory_t *homekit_accessory_default(homekit_accessory_t
 // Macro to define accessory
 #define HOMEKIT_ACCESSORY(...) \
         homekit_accessory_default(&(homekit_accessory_t) { \
-                ##__VA_ARGS__ \
+                __VA_ARGS__ \
         })
 
 // Macro to define service inside accessory definition.


### PR DESCRIPTION
### Motivation
- Fix a downstream ESP-IDF compile error where `HOMEKIT_ACCESSORY(.id = ...)` expansions triggered a preprocessor failure (`pasting "{" and "." does not give a valid preprocessing token`).

### Description
- Change the `HOMEKIT_ACCESSORY` variadic macro in `include/homekit/types.h` to use `__VA_ARGS__` instead of the GNU comma-swallowing token-paste `##__VA_ARGS__`, so compound literal initializers starting with designated fields expand correctly.

### Testing
- Ran a local syntax check `cc -std=gnu17 -Iinclude -fsyntax-only /tmp/homekit_macro_check.c` using a function-scope `HOMEKIT_ACCESSORY(...)` usage with designated initializers and it succeeded.
- Ran `git diff --check` for whitespace/errors and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69931e954984832193c47da10055f278)