### PR TITLE
Fix malformed HOMEKIT_ACCESSORY macro expansion

### DIFF
--- a/include/homekit/types.h
+++ b/include/homekit/types.h
@@ -250,7 +250,7 @@ void homekit_characteristic_default_setter_ex(homekit_characteristic_t *ch, home
 #define HOMEKIT_ACCESSORY(...) \
         &(homekit_accessory_t) { \
                 __VA_ARGS__ \
-        })
+        }
 
 // Macro to define service inside accessory definition.
 // Requires HOMEKIT_SERVICE_<name> define to expand to service type UUID string


### PR DESCRIPTION
### Motivation
- Fix a compile-time syntax error (`expected '}' before ')'`) caused by an extra closing parenthesis in the `HOMEKIT_ACCESSORY` macro used when defining accessory compound literals (file `include/homekit/types.h`).

### Description
- Corrected the `HOMEKIT_ACCESSORY` macro in `include/homekit/types.h` to terminate the compound literal with `}` instead of `})`, so it expands to `&(homekit_accessory_t){ ... }`.

### Testing
- Ran `idf.py --version` in `examples/led`, which succeeded; and attempted `idf.py build` in `examples/led`, which reached CMake dependency resolution but failed due to inability to contact the Espressif component registry (network/environment issue), not due to the fixed macro.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932122fa688321bd517be0db997b5e)