### PR TITLE
Fix Curve25519 shared-secret sizing and RNG cleanup

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -94,7 +94,7 @@ int crypto_ed25519_verify(
 
 // CURVE25519
 int crypto_curve25519_init(curve25519_key *key);
-int crypto_curve25519_done(curve25519_key *key);
+void crypto_curve25519_done(curve25519_key *key);
 int crypto_curve25519_generate(curve25519_key *key);
 int crypto_curve25519_import_public(
         curve25519_key *key,


### PR DESCRIPTION
### Motivation
- Pair-verify calls the Curve25519 shared-secret helper twice (a size probe then compute), but the helper previously returned an error on the probe, causing allocation/compute failures. 
- RNG lifecycle and error paths in `crypto_curve25519_generate` were not fully cleaned up which can leak RNG state or leave partially initialized key state. 
- Header declaration for `crypto_curve25519_done` did not match the implementation, risking signature mismatch across translation units.

### Description
- Make `crypto_curve25519_shared_secret` behave like size-query APIs by returning the required `CURVE25519_KEYSIZE` when `*size == 0` and by adding a `size == NULL` guard. 
- Improve `crypto_curve25519_generate` to initialize/track the RNG (`bool rng_initialized`), free the RNG with `wc_FreeRng` on success/failure, clean up key state on RNG init failure, and use `CURVE25519_KEYSIZE` instead of hardcoded `32`.
- Add `#include <stdbool.h>` to `src/crypto.c` for the new boolean variable. 
- Correct the declaration of `crypto_curve25519_done` in `src/crypto.h` from `int` to `void` to match the implementation.

### Testing
- Ran `cmake -S . -B build` to exercise configuration; the command failed in this environment due to missing ESP-IDF CMake functions (`Unknown CMake command "idf_component_register"`), so a full build could not be performed here. 
- No other automated tests are available in this environment; changes are limited to API semantics and RNG lifecycle handling and should be verifiable by performing a normal ESP-IDF build and running pair-verify pairing flows which previously failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699325847da08321adc423ae66d3cdd7)