### PR TITLE
Reset stale pairing context when Pair Setup is restarted

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1325,16 +1325,20 @@
                                  CLIENT_INFO(context, "Refusing to pair: another pairing in progress");
                                  send_tlv_error_response(context, 2, TLVError_Busy);
                                  break;
+                         } else {
+                                 CLIENT_INFO(context, "Restarting existing pairing session");
+                                 pairing_context_free(context->server->pairing_context);
+                                 context->server->pairing_context = NULL;
                          }
-                 } else {
-                         context->server->pairing_context = pairing_context_new();
-                         if (!context->server->pairing_context) {
-                                 CLIENT_ERROR(context, "Refusing to pair: failed to allocate memory for pairing context");
-                                 send_tlv_error_response(context, 2, TLVError_Unknown);
-                                 break;
-                         }
-                         context->server->pairing_context->client = context;
                  }
+
+                 context->server->pairing_context = pairing_context_new();
+                 if (!context->server->pairing_context) {
+                         CLIENT_ERROR(context, "Refusing to pair: failed to allocate memory for pairing context");
+                         send_tlv_error_response(context, 2, TLVError_Unknown);
+                         break;
+                 }
+                 context->server->pairing_context->client = context;
 
                  CLIENT_DEBUG(context, "Initializing crypto");
                  DEBUG_HEAP();


### PR DESCRIPTION
### Motivation
- Handle retries of HomeKit Pair Setup from the same client by avoiding reuse of stale SRP state that can cause SRP initialization and verification failures. 
- Preserve existing behavior that refuses new pairing when a different client is already in progress.

### Description
- When `Pair Setup` step 1 is received and an existing `pairing_context` belongs to the same client, free the old `pairing_context` and log a restart instead of reusing it. 
- Always allocate a fresh `pairing_context` and bind it to the current client before calling `crypto_srp_init`, ensuring a clean SRP state for each attempt. 
- Kept the existing busy response (`TLVError_Busy`) when another client is actively pairing. 
- Change implemented in `src/server.c` around the Pair Setup handling logic.

### Testing
- Ran `git diff --check` which produced no issues and succeeded. 
- Inspected the change with `git diff -- src/server.c` and validated the intended edits. 
- Verified repository status with `git status --short` and created a commit with the message `Fix pairing restart by resetting stale SRP context` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699327db82048321bb6536edca009e62)