### PR TITLE
Reset pairing_context on Pair Setup restart to avoid stale SRP state

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1326,15 +1326,19 @@
                                 send_tlv_error_response(context, 2, TLVError_Busy);
                                 break;
                         }
-                } else {
-                        context->server->pairing_context = pairing_context_new();
-                        if (!context->server->pairing_context) {
-                                CLIENT_ERROR(context, "Refusing to pair: failed to allocate memory for pairing context");
-                                send_tlv_error_response(context, 2, TLVError_Unknown);
-                                break;
-                        }
-                        context->server->pairing_context->client = context;
+
+                        CLIENT_DEBUG(context, "Restarting pair setup with fresh SRP context");
+                        pairing_context_free(context->server->pairing_context);
+                        context->server->pairing_context = NULL;
                 }
+
+                context->server->pairing_context = pairing_context_new();
+                if (!context->server->pairing_context) {
+                        CLIENT_ERROR(context, "Refusing to pair: failed to allocate memory for pairing context");
+                        send_tlv_error_response(context, 2, TLVError_Unknown);
+                        break;
+                }
+                context->server->pairing_context->client = context;
 
                  CLIENT_DEBUG(context, "Initializing crypto");
                  DEBUG_HEAP();


### PR DESCRIPTION
### Motivation
- Intermittent SRP failures were observed during Pair Setup retries (e.g. `Failed to verify peer's proof` and `Failed to set SRP password`) caused by reusing an existing SRP context from a previous pairing attempt. 
- The intent is to ensure each Pair Setup step 1 starts with a clean SRP state for the requesting client so SRP operations do not fail due to stale/internal state.

### Description
- If a `pairing_context` already exists for the same client, free it and log a debug message before creating a fresh `pairing_context` so SRP state is reset. 
- Preserve the existing busy-check behavior for other clients to avoid interfering with concurrent pairing attempts. 
- Changes are localized to the Pair Setup step 1 flow in `src/server.c` and set the new context's `client` field after allocation.

### Testing
- Ran `git diff --check` to validate whitespace/style issues and it passed. 
- Performed repository status checks and committed the change successfully as part of the automated workflow steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932c0d5d108321afa600c8fd756b96)