### PR TITLE
Fix bitset allocation & query parser; add ASan host CI and regression tests

### DIFF
--- a/.github/workflows/esp-idf-compat.yml
+++ b/.github/workflows/esp-idf-compat.yml
@@ -9,6 +9,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  host-sanity:
+    name: host-sanity (asan)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build and run host regression tests
+        shell: bash
+        run: |
+          set -euxo pipefail
+          gcc -std=c11 -Wall -Wextra -Werror -pedantic \
+            -fsanitize=address,undefined -fno-omit-frame-pointer \
+            -Iinclude -Isrc \
+            tests/host/test_core.c src/base64.c src/query_params.c src/bitset.c \
+            -o /tmp/homekit-host-tests
+          /tmp/homekit-host-tests
+
   build:
     name: idf-${{ matrix.idf }} / ${{ matrix.target }}
     runs-on: ubuntu-latest

--- a/.github/workflows/host-regression-tests.yml
+++ b/.github/workflows/host-regression-tests.yml
@@ -1,0 +1,31 @@
+name: Host regression tests
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  host-tests:
+    name: asan-ubsan-host-tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Compile and run host regression tests
+        shell: bash
+        run: |
+          set -euxo pipefail
+          gcc -std=c11 -Wall -Wextra -Werror -pedantic \
+            -fsanitize=address,undefined -fno-omit-frame-pointer \
+            -Iinclude -Isrc \
+            tests/host/test_core.c src/base64.c src/query_params.c src/bitset.c \
+            -o /tmp/homekit-host-tests
+          /tmp/homekit-host-tests

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ docker run -it -v ~/esp32-homekit-demo:/project -w /project espressif/idf:v6.0
 ```
 
 > This component is CI-tested on ESP-IDF **v5.3** and **v6.0** to keep backward compatibility while supporting the latest major release.
+>
+> Separate GitHub Actions host regression tests (`Host regression tests`) also run sanitizer-backed checks (ASan/UBSan) against core modules on each push/PR.
 
 ### 3. Configuration
 ```sh

--- a/docs/CODE_AUDIT_2026-03-26.md
+++ b/docs/CODE_AUDIT_2026-03-26.md
@@ -1,0 +1,52 @@
+# Code Audit Report — 2026-03-26
+
+## Scope
+- Core C modules in `src/` with emphasis on memory-safety, API robustness, and parser correctness.
+- Existing CI workflow in `.github/workflows/esp-idf-compat.yml`.
+- New host-side regression tests in `tests/host/test_core.c`.
+
+## Method
+1. Manual review of core low-level modules (`bitset`, `base64`, `query_params`) for arithmetic, bounds, and null handling.
+2. Added host-executable regression tests to exercise code paths independently of ESP-IDF.
+3. Added sanitizer-backed CI gate (`ASan` + `UBSan`) to catch latent memory/UB issues early.
+
+## Findings
+
+### 1) Critical: heap under-allocation in `bitset_new`
+**File:** `src/bitset.c`
+
+- **Issue:** allocation used `sizeof(bitset_t) + (size + 7 / 8)` where `7 / 8` is integer `0`.
+- **Impact:** only `size` bytes were reserved for bit storage instead of `ceil(size/8)`, leading to invalid memory writes for many sizes and hard-to-debug corruption.
+- **Fix:** changed to `sizeof(bitset_t) + ((size + 7) / 8)` and added `NULL` handling after `malloc`.
+
+### 2) High: out-of-bounds read in `bitset_isset`
+**File:** `src/bitset.c`
+
+- **Issue:** no bounds check for `index` before reading bit array.
+- **Impact:** potential out-of-bounds read and undefined behavior on malformed input paths.
+- **Fix:** return `false` when `index >= bs->size`.
+
+### 3) Medium: public headers rely on transitive includes
+**Files:** `src/bitset.h`, `src/query_params.h`
+
+- **Issue:** `bool` and `size_t` were used without including canonical headers (`<stdbool.h>`, `<stddef.h>`).
+- **Impact:** fragile compilation behavior depending on include order.
+- **Fix:** added explicit includes in both headers.
+
+## CI hardening added
+
+- Added `host-sanity (asan)` job to `.github/workflows/esp-idf-compat.yml`.
+- Job compiles and runs host regression tests with:
+  - `-Wall -Wextra -Werror -pedantic`
+  - `-fsanitize=address,undefined -fno-omit-frame-pointer`
+- This catches memory bugs independently from embedded toolchains and before long ESP-IDF matrix builds.
+
+## Residual risk / next recommendations
+
+1. Add fuzz targets for parser/decoder modules (`query_params`, `tlv`, `json`) and run nightly.
+2. Enable static analysis (`clang-tidy`/`cppcheck`) as non-blocking first phase.
+3. Expand host tests to cover malformed base64 inputs and boundary behavior for zero-sized bitsets.
+
+## Status summary
+- Critical/high findings in reviewed modules were remediated in this change set.
+- CI now includes a fast, deterministic safety gate for regressions.

--- a/src/base64.c
+++ b/src/base64.c
@@ -24,6 +24,7 @@ unsigned char base64_decode_char(unsigned char c) {
 }
 
 size_t base64_encoded_size(const unsigned char *data, size_t size) {
+        (void) data;
         return (size + 2)/3*4;
 }
 

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -11,7 +11,10 @@ typedef struct _bitset {
 
 
 bitset_t *bitset_new(uint16_t size) {
-        bitset_t *bs = malloc(sizeof(bitset_t) + (size + 7 / 8));
+        bitset_t *bs = malloc(sizeof(bitset_t) + ((size + 7) / 8));
+        if (!bs)
+                return NULL;
+
         bs->data = ((uint8_t*)bs) + sizeof(bitset_t);
         bs->size = size;
         memset(bs->data, 0, (size + 7) / 8);
@@ -30,6 +33,9 @@ void bitset_clear_all(bitset_t *bs) {
 
 
 bool bitset_isset(bitset_t *bs, uint16_t index) {
+        if (index >= bs->size)
+                return false;
+
         return (bs->data[index / 8] & (1 << (index % 8))) != 0;
 }
 

--- a/src/bitset.h
+++ b/src/bitset.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 typedef struct _bitset bitset_t;

--- a/src/debug.h
+++ b/src/debug.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 typedef unsigned char byte;
 

--- a/src/query_params.c
+++ b/src/query_params.c
@@ -13,13 +13,17 @@ int query_param_iterator_init(query_param_iterator_t *it, const char *s, size_t 
 }
 
 void query_param_iterator_done(query_param_iterator_t *it) {
+        (void) it;
 }
 
 bool query_param_iterator_next(query_param_iterator_t *it, query_param_t *param) {
+        while (it->pos < it->len && it->data[it->pos] == '&')
+                it->pos++;
+
         if (it->pos >= it->len || it->data[it->pos] == '#')
                 return false;
 
-        int pos = it->pos;
+        size_t pos = it->pos;
         while (it->pos < it->len &&
                it->data[it->pos] != '=' &&
                it->data[it->pos] != '&' &&

--- a/src/query_params.h
+++ b/src/query_params.h
@@ -2,6 +2,7 @@
 #define __HOMEKIT_QUERY_PARAMS__
 
 #include <stdbool.h>
+#include <stddef.h>
 
 typedef struct {
         char *data;

--- a/tests/host/test_core.c
+++ b/tests/host/test_core.c
@@ -1,0 +1,76 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "base64.h"
+#include "bitset.h"
+#include "query_params.h"
+
+static void test_base64_roundtrip(void) {
+    const unsigned char input[] = "HomeKit-ESP32";
+    unsigned char encoded[64] = {0};
+    unsigned char decoded[64] = {0};
+
+    int encoded_len = base64_encode(input, strlen((const char *)input), encoded);
+    assert(encoded_len > 0);
+    assert((size_t)encoded_len == base64_encoded_size(input, strlen((const char *)input)));
+
+    int decoded_len = base64_decode(encoded, encoded_len, decoded);
+    assert(decoded_len == (int)strlen((const char *)input));
+    assert(memcmp(decoded, input, strlen((const char *)input)) == 0);
+}
+
+static void test_query_params_iter(void) {
+    const char *query = "foo=bar&empty=&flag#fragment";
+    query_param_iterator_t it;
+    query_param_t p;
+
+    assert(query_param_iterator_init(&it, query, strlen(query)) == 0);
+
+    assert(query_param_iterator_next(&it, &p));
+    assert(p.name_len == 3 && strncmp(p.name, "foo", p.name_len) == 0);
+    assert(p.value_len == 3 && strncmp(p.value, "bar", p.value_len) == 0);
+
+    assert(query_param_iterator_next(&it, &p));
+    assert(p.name_len == 5 && strncmp(p.name, "empty", p.name_len) == 0);
+    assert(p.value == NULL && p.value_len == 0);
+
+    assert(query_param_iterator_next(&it, &p));
+    assert(p.name_len == 4 && strncmp(p.name, "flag", p.name_len) == 0);
+    assert(p.value == NULL && p.value_len == 0);
+
+    assert(!query_param_iterator_next(&it, &p));
+    query_param_iterator_done(&it);
+}
+
+static void test_bitset_boundaries(void) {
+    bitset_t *bs = bitset_new(128);
+    assert(bs != NULL);
+
+    for (uint16_t i = 0; i < 128; i++) {
+        assert(!bitset_isset(bs, i));
+        bitset_set(bs, i);
+        assert(bitset_isset(bs, i));
+    }
+
+    bitset_set(bs, 128);
+    assert(!bitset_isset(bs, 128));
+
+    for (uint16_t i = 0; i < 128; i++) {
+        bitset_clear(bs, i);
+        assert(!bitset_isset(bs, i));
+    }
+
+    bitset_free(bs);
+}
+
+int main(void) {
+    test_base64_roundtrip();
+    test_query_params_iter();
+    test_bitset_boundaries();
+
+    puts("host tests passed");
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Harden core low-level modules for memory-safety and deterministic compilation across hosts and toolchains.
- Add a fast, sanitizer-backed CI gate to catch memory/UB regressions before expensive ESP-IDF matrix builds. 
- Provide a written audit and reproducible host tests to prevent regressions and document findings.

### Description
- Fixed a critical allocation bug in `bitset_new` by computing bytes as `((size + 7) / 8)` and added a `NULL` guard after `malloc` to avoid use-after-failure. 
- Added a bounds check to `bitset_isset` to prevent out-of-bounds reads and adjusted related header hygiene by adding `<stdbool.h>` in `src/bitset.h`. 
- Made the query parameter iterator more robust by skipping leading `&` separators, using `size_t` for positions, and adding `<stddef.h>` to `src/query_params.h`. 
- Improved `src/debug.h` includes by adding `<stdint.h>` and silenced an unused-parameter warning in `src/base64.c`. 
- Added a host regression test executable at `tests/host/test_core.c` exercising `base64`, `query_params`, and `bitset` behavior. 
- Introduced a sanitizer-backed CI job `host-sanity (asan)` in `.github/workflows/esp-idf-compat.yml` that compiles and runs the host tests with `-fsanitize=address,undefined` and strict warnings. 
- Added a detailed audit report at `docs/CODE_AUDIT_2026-03-26.md` describing scope, findings, fixes, and next recommendations.

### Testing
- Built and executed the host regression suite locally with: `gcc -std=c11 -Wall -Wextra -Werror -pedantic -fsanitize=address,undefined -fno-omit-frame-pointer -Iinclude -Isrc tests/host/test_core.c src/base64.c src/query_params.c src/bitset.c -o /tmp/homekit-host-tests && /tmp/homekit-host-tests`, and the run completed successfully with `host tests passed`.
- CI was extended with the `host-sanity (asan)` job to run the same sanitizer-backed compilation and tests (intended to run on GitHub Actions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55120f6a883219ac0b5a5cfcf99ea)