### PR TITLE
Parameterize examples/led in ESP-IDF CI and expand matrix to cover requested chips

### DIFF
--- a/.github/workflows/esp-idf-compat.yml
+++ b/.github/workflows/esp-idf-compat.yml
@@ -39,12 +39,13 @@ jobs:
       IDF_COMPONENT_STORAGE_URL: https://components-file.espressif.com/
       IDF_COMPONENT_API_TIMEOUT: "120"
       IDF_COMPONENT_API_CACHE_EXPIRATION_MINUTES: "120"
+      EXAMPLE_APP_DIR: examples/led
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
         include:
-          # Backward compatibility line (ESP-IDF v5.x)
+          # Backward compatibility line (ESP-IDF v5.3)
           - idf: "release/v5.3"
             target: "esp32"
           - idf: "release/v5.3"
@@ -57,7 +58,7 @@ jobs:
             target: "esp32c3"
           - idf: "release/v5.3"
             target: "esp32c6"
-          # Latest major line (ESP-IDF v6.x)
+          # Latest major line (ESP-IDF v6.0)
           - idf: "release/v6.0"
             target: "esp32"
           - idf: "release/v6.0"
@@ -109,7 +110,7 @@ jobs:
         run: |
           set -euxo pipefail
           . "${IDF_PATH}/export.sh"
-          cd examples/led
+          cd "${EXAMPLE_APP_DIR}"
           idf.py --version
           idf.py set-target "${{ matrix.target }}"
           for attempt in 1 2 3; do
@@ -130,7 +131,7 @@ jobs:
         with:
           name: esp-idf-logs-${{ replace(matrix.idf, '/', '-') }}-${{ matrix.target }}
           path: |
-            examples/led/build/log/
-            examples/led/build/CMakeFiles/CMakeError.log
-            examples/led/build/CMakeFiles/CMakeOutput.log
+            ${{ env.EXAMPLE_APP_DIR }}/build/log/
+            ${{ env.EXAMPLE_APP_DIR }}/build/CMakeFiles/CMakeError.log
+            ${{ env.EXAMPLE_APP_DIR }}/build/CMakeFiles/CMakeOutput.log
           if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git clone --recursive https://github.com/AchimPieters/esp32-homekit-demo.git
 docker run -it -v ~/esp32-homekit-demo:/project -w /project espressif/idf:v6.0
 ```
 
-> This component is CI-tested on ESP-IDF **v5.3** and **v6.0** to keep backward compatibility while supporting the latest major release.
+> This component is CI-tested on ESP-IDF **v5.3** (`esp32`, `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c6`) and **v6.0** (`esp32`, `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`) using `examples/led` as compile smoke test coverage.
 >
 > Separate GitHub Actions host regression tests (`Host regression tests`) also run sanitizer-backed checks (ASan/UBSan) against core modules on each push/PR.
 


### PR DESCRIPTION
### Motivation
- Ensure practical compile-compatibility across specific ESP32 families by exercising `examples/led` under the CI matrix for both IDF v5.3 and v6.0.
- Make the workflow paths consistent and easier to change by centralizing the example app directory.

### Description
- Add `EXAMPLE_APP_DIR: examples/led` to the `build` job environment and use it for `cd` before `idf.py` invocations.
- Replace hard-coded `examples/led` artifact paths with `${{ env.EXAMPLE_APP_DIR }}` so build logs are uploaded from the configured app directory.
- Clarify matrix comments to reference `release/v5.3` and `release/v6.0` explicitly and keep the expanded matrix rows for the requested targets: IDF v5.3 (`esp32`, `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c6`) and IDF v6.0 (`esp32`, `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`).
- Update `README.md` to document the exact tested chip families and note `examples/led` as the compile smoke test basis.

### Testing
- Ran `git diff --check` to validate whitespace/formatting and it succeeded.
- Reviewed the workflow and README diffs with `git diff` and `nl` to confirm the matrix entries and path substitutions, and those checks succeeded.
- Committed the changes locally; no CI job runs were executed as part of these edits in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68d074ea8832192ae0a2a6baec6e0)