### PR TITLE
Audit round 2: notify deadlock, ev-permission, mDNS hardening

### DIFF
--- a/docs/CODE_AUDIT_2026-06-06_round2.md
+++ b/docs/CODE_AUDIT_2026-06-06_round2.md
@@ -1,0 +1,96 @@
+# Code Audit Report — 2026-06-06 (ronde 2)
+
+## Scope
+Vervolgaudit op `main` (`d971505`, ná de fixes van ronde 1). Nadruk op modules die in
+ronde 1 niet diep zijn bekeken: `homekit_mdns.c`, `debug.c`, `homekit_mdns_debug.c`, de
+publieke macro's in `include/homekit/types.h`, en de concurrency-/lockpaden en logische
+operatoren in `server.c`. Tevens herverificatie dat de fixes van ronde 1 correct zijn.
+
+Ernst-legenda: **H** = High, **M** = Medium, **L/Info** = Low/informatief.
+
+---
+
+## Nieuwe bevindingen
+
+### N1 — High: deadlock in `homekit_characteristic_notify`
+**Bestand:** `src/server.c` (~regel 3904–3909)
+
+```c
+xSemaphoreTake(server->notification_lock, portMAX_DELAY);
+
+characteristic_info_t *ch_info = find_characteristic_info_by_characteristic(server, ch);
+if (!ch_info) {
+        ERROR("Trying notify on unknown characteristic \"%s\"", ch->description);
+        return;          // <-- keert terug ZONDER xSemaphoreGive
+}
+```
+
+De fouttak keert terug terwijl `notification_lock` nog vastgehouden wordt. Elke volgende
+`homekit_characteristic_notify` én `homekit_server_process_notifications` blokkeert dan
+voorgoed op `xSemaphoreTake(..., portMAX_DELAY)` → de HomeKit-servertaak hangt volledig.
+
+**Trigger:** een accessoire dat `homekit_characteristic_notify()` aanroept op een
+characteristic die niet in de geregistreerde accessoireboom zit (bijv. een losse of
+dynamisch aangemaakte characteristic). Goed bedoelde gebruikerscode kan dit raken.
+
+**Fix:** `xSemaphoreGive(server->notification_lock);` vóór de `return`.
+
+---
+
+### N2 — Medium: logische `&&` i.p.v. bitwise `&` in `ev`-permissiecontrole
+**Bestand:** `src/server.c` (~regel 3078), `homekit_server_on_update_characteristics`
+
+```c
+if (!(ch->permissions && homekit_permissions_notify)) {
+        ... "notifications are not supported" ...
+}
+```
+
+`homekit_permissions_notify` is een vaste, niet-nul constante, dus de uitdrukking is
+feitelijk `(ch->permissions != 0)`. De bedoelde controle "heeft deze characteristic de
+notify-permissie?" werkt daardoor niet: de tak slaat alleen aan als `permissions == 0`.
+
+**Impact:** een gepairde client kan zich abonneren (`"ev": true`) op een characteristic
+die de notify-permissie **niet** heeft, zolang die characteristic enige andere permissie
+heeft. Vervolgens wordt `client_subscribe_to_characteristic_events` aangeroepen op een
+niet-notify characteristic. Afwijking van de HAP-spec en onverwachte abonnementsstaat.
+
+**Fix:** gebruik bitwise `&`: `if (!(ch->permissions & homekit_permissions_notify))`.
+(Vergelijk de correcte vorm op regels 694, 705, 3901, 4285, 4374.)
+
+---
+
+### N3 — Info/Low: mDNS-pakketparser ongehard (niet in de ESP-IDF-build)
+**Bestand:** `src/homekit_mdns.c` — **uitgesloten via `EXCLUDE_SRCS` in `CMakeLists.txt`**,
+dus niet aanwezig in de geleverde ESP-IDF-firmware (daar gebruikt `port.c` de officiële
+IDF `mdns`-component). Alleen relevant voor `ESP_OPEN_RTOS`/`HOST_BUILD`.
+
+Twee klassieke DNS-parserrisico's in `mdns_server_process_query`:
+1. **Geen header-lengtecheck:** `mdns_read_u16(data + 4/6/8)` (regels 786–788) leest vóór
+   enige controle dat `data_len >= MDNS_HEADER_SIZE (12)`. Een UDP-pakket < 12 bytes geeft
+   een out-of-bounds read.
+2. **Decompressie-lus:** `mdns_match_label` (regel 367) volgt naam-compressiepointers
+   (`0xC0`). Een pakket met een pointer die naar zichzelf (of een cyclus) wijst kan een
+   oneindige lus veroorzaken — DoS. Er is geen teller/bezochte-offsetbewaking.
+
+**Aanbeveling:** als dit pad ooit weer gebouwd wordt, valideer `data_len >= 12` aan het
+begin van `mdns_server_process_query` en begrens het aantal te volgen compressiepointers.
+
+---
+
+## Herverificatie ronde 1
+De fixes uit `CODE_AUDIT_2026-06-06.md` zijn aanwezig en correct in `main`:
+- H1/H2 (`id_index`, `id_count`-grens), H3 (`HOMEKIT_MAX_BODY_SIZE` + NULL/overflow),
+  H4 (`tlv_parse`-grenzen), M1 (`crypto_ed25519_verify` fail-closed), M2 (range-`sizeof`),
+  M3 (device-id lengtechecks), M4 (RNG-free/NULL), M5 (decrypt-offset), L1–L7.
+- Host-tests (incl. de nieuwe base64/tlv-regressietests) bouwen en slagen.
+- `HOMEKIT_ACCESSORY/SERVICE/CHARACTERISTIC`-macro's in `types.h` zijn correct (de oude
+  Feb-2026 macro-bugs zijn in 3.0.0 verholpen).
+
+`debug.c` (`text_to_stringv`/`binary_to_stringv`): buffergroottes worden correct berekend
+(`\xXX` = 4 bytes gebudgetteerd); alleen actief onder `HOMEKIT_DEBUG`. Geen bevindingen.
+
+## Statusoverzicht
+- 1 High (N1), 1 Medium (N2) in code die in de ESP-IDF-firmware meedraait.
+- 1 informatieve bevinding (N3) in een module die buiten de IDF-build valt.
+- Geen wijzigingen aangebracht in deze audit; dit rapport is uitsluitend bevindend.

--- a/src/homekit_mdns.c
+++ b/src/homekit_mdns.c
@@ -55,6 +55,7 @@
 #include <timers.h>
 
 #include "homekit_mdns_private.h"
+#include "mdns_name.h"
 #include "homekit_mdns.h"
 #include "homekit_mdns_debug.h"
 
@@ -363,26 +364,6 @@ typedef enum {
 } name_t;
 
 
-static int mdns_match_label(uint8_t *data, uint16_t size, uint16_t offset, const char *name, uint8_t len) {
-        while (offset + 1 < size && (data[offset] & 0xC0) == 0xC0) {
-                offset = ((data[offset] & 0x3F) << 8) + data[offset+1];
-                if (offset >= size)
-                        return -1;
-        }
-
-        if (offset + 1 + len > size)
-                return -1;
-
-        if (data[offset] != len)
-                return -1;
-
-        if (len && memcmp(data + 1 + offset, name, len))
-                return -1;
-
-        return offset + 1 + len;
-}
-
-
 static int mdns_match_name(mdns_server_t *server, uint8_t *data, uint16_t size, uint16_t offset, name_t name_id) {
         int x = offset;
         switch (name_id) {
@@ -407,21 +388,6 @@ static int mdns_match_name(mdns_server_t *server, uint8_t *data, uint16_t size, 
                 x = 0;
         }
         return x;
-}
-
-
-static int mdns_skip_name(uint8_t *data, uint16_t size, uint16_t offset) {
-        while (offset < size && data[offset] && !(data[offset] & 0xC0)) {
-                offset += 1 + data[offset];
-        }
-
-        if (offset >= size)
-                return -1;
-
-        if ((data[offset] & 0xC0) == 0xC0)
-                return offset + 2;
-
-        return offset + 1;
 }
 
 
@@ -779,6 +745,10 @@ void mdns_server_done(mdns_server_t *server) {
 
 static void mdns_server_process_query(mdns_server_t *server, uint8_t *data, uint16_t data_len, struct sockaddr *peer_addr, socklen_t peer_addr_len) {
         // LOG_DEBUG("Processing query");
+
+        // Drop runt packets that are too short to contain a DNS header.
+        if (data_len < MDNS_HEADER_SIZE)
+                return;
         // mdns_print_packet(data, data_len);
 
         // uint16_t packet_id = mdns_read_u16(data + 0);

--- a/src/mdns_name.h
+++ b/src/mdns_name.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+// Pure DNS name-parsing helpers shared by the (ESP-OPEN-RTOS / host) mDNS
+// responder. Kept header-only and free of platform dependencies so they can be
+// unit-tested on the host. All functions take the raw packet (data/size) plus a
+// byte offset and return the offset just past the matched/skipped name, or a
+// negative value on malformed input.
+
+// Maximum number of DNS name-compression pointers to follow before giving up.
+// Guards against an infinite loop on a packet with cyclic compression pointers.
+#ifndef MDNS_MAX_COMPRESSION_POINTERS
+#define MDNS_MAX_COMPRESSION_POINTERS 8
+#endif
+
+static inline int mdns_match_label(uint8_t *data, uint16_t size, uint16_t offset, const char *name, uint8_t len) {
+        int pointers = 0;
+        while (offset + 1 < size && (data[offset] & 0xC0) == 0xC0) {
+                if (++pointers > MDNS_MAX_COMPRESSION_POINTERS)
+                        return -1;
+                offset = ((data[offset] & 0x3F) << 8) + data[offset+1];
+                if (offset >= size)
+                        return -1;
+        }
+
+        if (offset + 1 + len > size)
+                return -1;
+
+        if (data[offset] != len)
+                return -1;
+
+        if (len && memcmp(data + 1 + offset, name, len))
+                return -1;
+
+        return offset + 1 + len;
+}
+
+static inline int mdns_skip_name(uint8_t *data, uint16_t size, uint16_t offset) {
+        while (offset < size && data[offset] && !(data[offset] & 0xC0)) {
+                offset += 1 + data[offset];
+        }
+
+        if (offset >= size)
+                return -1;
+
+        if ((data[offset] & 0xC0) == 0xC0)
+                return offset + 2;
+
+        return offset + 1;
+}

--- a/src/server.c
+++ b/src/server.c
@@ -3075,7 +3075,7 @@
 
                  cJSON *j_events = cJSON_GetObjectItem(j_ch, "ev");
                  if (j_events) {
-                         if (!(ch->permissions && homekit_permissions_notify)) {
+                         if (!(ch->permissions & homekit_permissions_notify)) {
                                  CLIENT_ERROR(context, "Failed to set notification state for %d.%d: "
                                               "notifications are not supported", aid, iid);
                                  return HAPStatus_NotificationsUnsupported;
@@ -3906,6 +3906,7 @@
          characteristic_info_t *ch_info = find_characteristic_info_by_characteristic(server, ch);
          if (!ch_info) {
                  ERROR("Trying notify on unknown characteristic \"%s\"", ch->description);
+                 xSemaphoreGive(server->notification_lock);
                  return;
          }
 

--- a/tests/host/test_core.c
+++ b/tests/host/test_core.c
@@ -7,6 +7,7 @@
 #include "base64.h"
 #include "bitset.h"
 #include "query_params.h"
+#include "mdns_name.h"
 #include <homekit/tlv.h>
 
 static void test_base64_roundtrip(void) {
@@ -133,6 +134,34 @@ static void test_tlv_parse_rejects_malformed(void) {
     }
 }
 
+static void test_mdns_name_parsing(void) {
+    // "local" label followed by root.
+    uint8_t local[] = {5, 'l','o','c','a','l', 0};
+    assert(mdns_match_label(local, sizeof(local), 0, "local", 5) == 6);
+    assert(mdns_match_label(local, sizeof(local), 0, "wrong", 5) == -1);
+    assert(mdns_match_label(local, sizeof(local), 0, "loc", 3) == -1); // length mismatch
+
+    // Truncated: length byte claims 5 but buffer is too short.
+    uint8_t trunc[] = {5, 'l','o','c'};
+    assert(mdns_match_label(trunc, sizeof(trunc), 0, "local", 5) == -1);
+
+    // Valid compression pointer: offset 0 -> points to offset 4 ("local").
+    uint8_t ptr[] = {0xC0, 0x04, 0x00, 0x00, 5, 'l','o','c','a','l'};
+    assert(mdns_match_label(ptr, sizeof(ptr), 0, "local", 5) == 10);
+
+    // Cyclic compression pointers must terminate (not hang) and report error.
+    uint8_t cyc[] = {0xC0, 0x02, 0xC0, 0x00};
+    assert(mdns_match_label(cyc, sizeof(cyc), 0, "local", 5) == -1);
+
+    // skip_name: normal name, pointer, and truncated.
+    uint8_t name[] = {5, 'l','o','c','a','l', 0};
+    assert(mdns_skip_name(name, sizeof(name), 0) == 7);
+    uint8_t pname[] = {0xC0, 0x00};
+    assert(mdns_skip_name(pname, sizeof(pname), 0) == 2);
+    uint8_t tname[] = {5, 'a', 'b'};
+    assert(mdns_skip_name(tname, sizeof(tname), 0) == -1);
+}
+
 int main(void) {
     test_base64_roundtrip();
     test_base64_rejects_invalid();
@@ -140,6 +169,7 @@ int main(void) {
     test_bitset_boundaries();
     test_tlv_parse_valid();
     test_tlv_parse_rejects_malformed();
+    test_mdns_name_parsing();
 
     puts("host tests passed");
     return 0;


### PR DESCRIPTION
Verhelpt docs/CODE_AUDIT_2026-06-06_round2.md.

- **N1 (High)** server.c: deadlock in homekit_characteristic_notify (semaphore niet vrijgegeven bij onbekende characteristic). Nu xSemaphoreGive vóór return.
- **N2 (Medium)** server.c: ev-abonnementscheck gebruikte logische && met de constante homekit_permissions_notify i.p.v. bitwise &. Nu &.
- **N3 (Info)** homekit_mdns.c (buiten IDF-build): pure DNS-naam-helpers naar testbare src/mdns_name.h; compressiepointers begrensd (geen oneindige lus); runt-pakketten < DNS-header gedropt.

CI: host-tests dekken nu mdns_name.h incl. een cyclische-pointer-case die moet termineren, onder ASan/UBSan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)