### PR TITLE
HomeKit camera HAP protocol layer (+ host tests, docs)

### DIFF
--- a/.github/workflows/host-regression-tests.yml
+++ b/.github/workflows/host-regression-tests.yml
@@ -23,6 +23,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
+          # Portable core modules: strict ISO C11.
           gcc -std=c11 -Wall -Wextra -Werror -pedantic -Wno-strict-prototypes \
             -fsanitize=address,undefined -fno-omit-frame-pointer \
             -Iinclude -Isrc \
@@ -31,3 +32,18 @@ jobs:
             -o /tmp/homekit-host-tests
           ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1 \
             /tmp/homekit-host-tests
+
+      - name: Compile and run camera protocol tests
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # The public homekit headers use GNU extensions (## __VA_ARGS__,
+          # compound literals), so the camera tests build as gnu11.
+          gcc -std=gnu11 -Wall -Wextra -Werror -Wno-strict-prototypes \
+            -fsanitize=address,undefined -fno-omit-frame-pointer \
+            -Iinclude -Isrc \
+            tests/host/test_camera.c \
+            src/camera.c src/tlv.c src/accessories.c \
+            -o /tmp/homekit-camera-tests
+          ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1 \
+            /tmp/homekit-camera-tests

--- a/docs/CAMERA.md
+++ b/docs/CAMERA.md
@@ -1,0 +1,124 @@
+# HomeKit Camera support
+
+This component ships the **HAP protocol layer** for a HomeKit IP Camera
+(`include/homekit/camera.h`, `src/camera.c`). It implements everything that is
+pure protocol and can run on any ESP32:
+
+- Supported **Video / Audio / RTP Stream Configuration** TLV8 blobs
+- **Setup Endpoints** request/response (parses the controller's address + SRTP
+  parameters, generates the accessory's SRTP master key/salt and SSRCs)
+- **Selected RTP Stream Configuration** commands
+  (Start / End / Suspend / Resume / Reconfigure) dispatched to your callbacks
+- **Streaming Status** characteristic (with notifications)
+- Still-image **snapshots** via the existing `on_resource` callback
+
+## What it does *not* do
+
+It is **not** a media pipeline. Live HomeKit video requires real-time **H.264**
+video and AAC-ELD/Opus/PCM audio, RTP packetization and **SRTP** encryption.
+The classic ESP32/ESP32-S3 has no H.264 encoder (ESP32-CAM produces MJPEG), so
+live streaming is only feasible on hardware with an encoder (e.g. ESP32-P4 or an
+external encoder chip). This module hands you the negotiated session — controller
+address, ports, SRTP keys/salts and SSRCs — and you feed frames from your H.264
+source into your own RTP/SRTP sender. **HomeKit Secure Video (HKSV)** is a
+separate, larger effort and is not included.
+
+> Official HAP compliance is gated by Apple's MFi certification program and test
+> tools (HAT); shipping code alone cannot grant certification. This module
+> targets spec-conformant wire behaviour but has not been certified.
+
+## Declaring a camera accessory
+
+Use accessory category `homekit_accessory_category_ip_camera` and a
+`Camera RTP Stream Management` service with the five TLV8 characteristics
+(+ optional Streaming Status). Keep references to the characteristics so you can
+bind them.
+
+```c
+#include <homekit/camera.h>
+
+homekit_characteristic_t cam_supported_video   = HOMEKIT_CHARACTERISTIC_(SUPPORTED_VIDEO_STREAM_CONFIGURATION);
+homekit_characteristic_t cam_supported_audio   = HOMEKIT_CHARACTERISTIC_(SUPPORTED_AUDIO_STREAM_CONFIGURATION);
+homekit_characteristic_t cam_supported_rtp     = HOMEKIT_CHARACTERISTIC_(SUPPORTED_RTP_CONFIGURATION);
+homekit_characteristic_t cam_setup_endpoints   = HOMEKIT_CHARACTERISTIC_(SETUP_ENDPOINTS);
+homekit_characteristic_t cam_selected_config   = HOMEKIT_CHARACTERISTIC_(SELECTED_RTP_STREAM_CONFIGURATION);
+homekit_characteristic_t cam_streaming_status  = HOMEKIT_CHARACTERISTIC_(STREAMING_STATUS);
+
+// ... place these in a HOMEKIT_SERVICE(CAMERA_RTP_STREAM_MANAGEMENT, ...) inside
+// an accessory whose category is homekit_accessory_category_ip_camera.
+```
+
+## Wiring the protocol layer
+
+```c
+static bool prepare_endpoints(homekit_camera_t *cam, homekit_camera_session_t *s) {
+    // Fill the accessory's own RTP endpoint (local IP + the UDP ports your
+    // media task bound). Return false to report a Setup Endpoints error.
+    s->accessory.ip_version = 0; // IPv4
+    strcpy(s->accessory.ip_address, my_local_ip_string);
+    s->accessory.video_port = my_video_rtp_port;
+    s->accessory.audio_port = my_audio_rtp_port;
+    return true;
+}
+
+static void on_stream_start(homekit_camera_t *cam, const homekit_camera_session_t *s) {
+    // s->controller.{ip_address,video_port,audio_port}        -> where to send media
+    // s->controller_video_srtp / s->accessory_video_srtp      -> SRTP keys/salts
+    // s->video_ssrc, s->selected_video.{width,height,fps}     -> stream params
+    // s->selected_video_max_bitrate (kbps)
+    media_task_start(s);
+}
+static void on_stream_end(homekit_camera_t *cam, const uint8_t id[16]) { media_task_stop(); }
+
+void app_main_setup_camera(void) {
+    static homekit_camera_config_t cfg = {
+        .h264_params = {{ homekit_camera_h264_profile_main, homekit_camera_h264_level_4_0 }},
+        .h264_param_count = 1,
+        .attributes = {{1920,1080,30}, {1280,720,30}, {640,480,30}},
+        .attribute_count = 3,
+        .audio = {{ homekit_camera_audio_codec_opus, 1, homekit_camera_audio_sample_rate_16khz, 20, true }},
+        .audio_count = 1,
+        .srtp_suites = { homekit_camera_srtp_crypto_aes_cm_128_hmac_sha1_80 },
+        .srtp_suite_count = 1,
+    };
+    static homekit_camera_callbacks_t cb = {
+        .prepare_endpoints     = prepare_endpoints,
+        .on_stream_start       = on_stream_start,
+        .on_stream_end         = on_stream_end,
+        // .on_stream_reconfigure / .on_stream_suspend / .on_stream_resume optional
+    };
+
+    homekit_camera_t *cam = homekit_camera_new(&cfg, &cb, NULL);
+    homekit_camera_bind(cam,
+        &cam_supported_video, &cam_supported_audio, &cam_supported_rtp,
+        &cam_setup_endpoints, &cam_selected_config, &cam_streaming_status);
+}
+```
+
+## Snapshots
+
+HomeKit fetches a still image with `POST /resource`
+(`{"resource-type":"image","image-width":W,"image-height":H}`). Implement
+`config.on_resource` and reply with an HTTP response carrying your JPEG via
+`homekit_client_send()`:
+
+```c
+void on_resource(const char *body, size_t body_size) {
+    // produce a JPEG of the requested size, then:
+    // 1) send an "HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nContent-Length: N\r\n\r\n" header
+    // 2) homekit_client_send(jpeg_bytes, jpeg_len);
+}
+```
+
+## Integrator checklist for live streaming
+
+1. Bind UDP sockets for video/audio RTP, report them in `prepare_endpoints`.
+2. On `on_stream_start`, start your H.264 (and audio) encoder at the selected
+   resolution/fps/bitrate.
+3. Packetize encoded frames into RTP and encrypt with SRTP using the SRTP master
+   key/salt from the session, sending to the controller's address/ports.
+4. Handle RTCP and the Suspend/Resume/Reconfigure/End commands.
+5. On `on_stream_end`, stop the encoder and free sockets.
+
+This module gets you a controller that successfully negotiates a session; steps
+1–5 (the media plane) are hardware/codec specific and are your responsibility.

--- a/include/homekit/camera.h
+++ b/include/homekit/camera.h
@@ -1,0 +1,250 @@
+#ifndef __HOMEKIT_CAMERA_H__
+#define __HOMEKIT_CAMERA_H__
+
+/**
+ * HomeKit IP Camera — HAP protocol layer.
+ *
+ * This module implements the *protocol* side of a HomeKit camera:
+ *   - the Supported Video / Audio / RTP Stream Configuration TLV8 blobs,
+ *   - the Setup Endpoints request/response (incl. accessory SRTP key + SSRC),
+ *   - the Selected RTP Stream Configuration command parsing
+ *     (start / stop / suspend / resume / reconfigure),
+ *   - the Streaming Status characteristic.
+ *
+ * It does NOT contain a media pipeline. Real-time H.264 video and audio
+ * encoding, RTP packetization and SRTP encryption are the integrator's
+ * responsibility: the module hands you the negotiated session (controller +
+ * accessory address, ports, SRTP keys/salts and SSRCs) via callbacks, and you
+ * feed frames from your H.264 source (e.g. an external encoder or an
+ * ESP32-P4-class device) into your own RTP/SRTP sender.
+ *
+ * Still-image snapshots are handled separately through the existing
+ * `on_resource` callback in homekit_server_config_t.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#include <homekit/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ---- Codec / parameter enumerations (HAP R2) ----
+
+typedef enum {
+        homekit_camera_video_codec_h264 = 0,
+} homekit_camera_video_codec_t;
+
+typedef enum {
+        homekit_camera_h264_profile_constrained_baseline = 0,
+        homekit_camera_h264_profile_main = 1,
+        homekit_camera_h264_profile_high = 2,
+} homekit_camera_h264_profile_t;
+
+typedef enum {
+        homekit_camera_h264_level_3_1 = 0,
+        homekit_camera_h264_level_3_2 = 1,
+        homekit_camera_h264_level_4_0 = 2,
+} homekit_camera_h264_level_t;
+
+typedef enum {
+        homekit_camera_audio_codec_pcmu = 0,
+        homekit_camera_audio_codec_pcma = 1,
+        homekit_camera_audio_codec_aac_eld = 2,
+        homekit_camera_audio_codec_opus = 3,
+        homekit_camera_audio_codec_msbc = 4,
+        homekit_camera_audio_codec_amr = 5,
+        homekit_camera_audio_codec_amr_wb = 6,
+} homekit_camera_audio_codec_t;
+
+typedef enum {
+        homekit_camera_audio_sample_rate_8khz = 0,
+        homekit_camera_audio_sample_rate_16khz = 1,
+        homekit_camera_audio_sample_rate_24khz = 2,
+} homekit_camera_audio_sample_rate_t;
+
+typedef enum {
+        homekit_camera_srtp_crypto_aes_cm_128_hmac_sha1_80 = 0,
+        homekit_camera_srtp_crypto_aes_256_cm_hmac_sha1_80 = 1,
+        homekit_camera_srtp_crypto_none = 2,
+} homekit_camera_srtp_crypto_suite_t;
+
+typedef enum {
+        homekit_camera_streaming_status_available = 0,
+        homekit_camera_streaming_status_in_use = 1,
+        homekit_camera_streaming_status_unavailable = 2,
+} homekit_camera_streaming_status_t;
+
+// ---- Accessory capability description ----
+
+typedef struct {
+        uint16_t width;
+        uint16_t height;
+        uint8_t  fps;
+} homekit_camera_video_attributes_t;
+
+typedef struct {
+        homekit_camera_h264_profile_t profile;
+        homekit_camera_h264_level_t   level;
+} homekit_camera_h264_param_t;
+
+typedef struct {
+        homekit_camera_audio_codec_t       codec;
+        uint8_t                            channels;       // typically 1
+        homekit_camera_audio_sample_rate_t sample_rate;
+        uint8_t                            rtp_time;       // packet time in ms (e.g. 20/30/60)
+        bool                               variable_bitrate;
+} homekit_camera_audio_config_t;
+
+// Up to these many entries are advertised; tune to taste / RAM.
+#define HOMEKIT_CAMERA_MAX_ATTRIBUTES   16
+#define HOMEKIT_CAMERA_MAX_H264_PARAMS  8
+#define HOMEKIT_CAMERA_MAX_AUDIO_CONFIGS 4
+#define HOMEKIT_CAMERA_MAX_SRTP_SUITES  3
+
+typedef struct {
+        // Supported video.
+        homekit_camera_h264_param_t       h264_params[HOMEKIT_CAMERA_MAX_H264_PARAMS];
+        size_t                            h264_param_count;
+        homekit_camera_video_attributes_t attributes[HOMEKIT_CAMERA_MAX_ATTRIBUTES];
+        size_t                            attribute_count;
+
+        // Supported audio.
+        homekit_camera_audio_config_t     audio[HOMEKIT_CAMERA_MAX_AUDIO_CONFIGS];
+        size_t                            audio_count;
+        bool                              comfort_noise;
+
+        // Supported SRTP crypto suites.
+        homekit_camera_srtp_crypto_suite_t srtp_suites[HOMEKIT_CAMERA_MAX_SRTP_SUITES];
+        size_t                             srtp_suite_count;
+} homekit_camera_config_t;
+
+// ---- Negotiated session ----
+
+typedef struct {
+        uint8_t  crypto_suite;     // homekit_camera_srtp_crypto_suite_t
+        uint8_t  master_key[32];
+        size_t   master_key_size;  // 16 (AES-128) or 32 (AES-256)
+        uint8_t  master_salt[14];
+        size_t   master_salt_size; // 14
+} homekit_camera_srtp_params_t;
+
+typedef struct {
+        uint8_t  ip_version;       // 0 = IPv4, 1 = IPv6
+        char     ip_address[46];   // textual address (max IPv6 length)
+        uint16_t video_port;
+        uint16_t audio_port;
+} homekit_camera_address_t;
+
+typedef enum {
+        homekit_camera_command_end = 0,
+        homekit_camera_command_start = 1,
+        homekit_camera_command_suspend = 2,
+        homekit_camera_command_resume = 3,
+        homekit_camera_command_reconfigure = 4,
+} homekit_camera_session_command_t;
+
+typedef struct {
+        uint8_t  session_id[16];
+
+        // Controller endpoint (where the accessory must send media to).
+        homekit_camera_address_t     controller;
+        homekit_camera_srtp_params_t controller_video_srtp;
+        homekit_camera_srtp_params_t controller_audio_srtp;
+
+        // Accessory endpoint (filled in by the module during Setup Endpoints).
+        homekit_camera_address_t     accessory;
+        homekit_camera_srtp_params_t accessory_video_srtp;
+        homekit_camera_srtp_params_t accessory_audio_srtp;
+        uint32_t                     video_ssrc;
+        uint32_t                     audio_ssrc;
+
+        // Selected stream parameters (filled in on Start/Reconfigure).
+        homekit_camera_video_attributes_t selected_video;
+        uint32_t                          selected_video_max_bitrate; // kbps
+        uint8_t                           selected_video_rtp_payload_type;
+        bool                              has_selected_video;
+} homekit_camera_session_t;
+
+// ---- Integrator callbacks ----
+//
+// All callbacks are invoked from the HomeKit server task. Keep them short:
+// hand work off to your media task rather than blocking here.
+
+typedef struct homekit_camera homekit_camera_t;
+
+typedef struct {
+        // Invoked during Setup Endpoints, before the response is built. The
+        // integrator must fill session->accessory (ip_version, ip_address,
+        // video_port, audio_port) with the accessory's own RTP endpoint (the
+        // local IP and the UDP ports its media stack bound). Return true on
+        // success; return false to report a Setup Endpoints error to the
+        // controller. If NULL, the module mirrors the controller's IP version
+        // and leaves ports at 0 (protocol completes but no media will flow).
+        bool (*prepare_endpoints)(homekit_camera_t *camera, homekit_camera_session_t *session);
+
+        // A controller selected a stream and issued Start. `session` is owned by
+        // the module and remains valid until on_stream_end for the same id.
+        void (*on_stream_start)(homekit_camera_t *camera, const homekit_camera_session_t *session);
+        // Controller issued Reconfigure (bitrate/attributes changed).
+        void (*on_stream_reconfigure)(homekit_camera_t *camera, const homekit_camera_session_t *session);
+        // Controller issued Suspend / Resume.
+        void (*on_stream_suspend)(homekit_camera_t *camera, const uint8_t session_id[16]);
+        void (*on_stream_resume)(homekit_camera_t *camera, const uint8_t session_id[16]);
+        // Controller issued End (or session torn down). Stop sending media.
+        void (*on_stream_end)(homekit_camera_t *camera, const uint8_t session_id[16]);
+} homekit_camera_callbacks_t;
+
+struct homekit_camera {
+        homekit_camera_config_t    config;
+        homekit_camera_callbacks_t callbacks;
+        void                      *context; // integrator-owned
+
+        // Internal state (managed by the module).
+        homekit_camera_session_t   session;       // single active session
+        bool                       session_active;
+        bool                       have_setup;     // a Setup Endpoints write happened
+        uint8_t                    last_setup_status; // 0=Success,1=Busy,2=Error
+        homekit_camera_streaming_status_t status;
+
+        homekit_characteristic_t  *ch_streaming_status;
+};
+
+// ---- API ----
+
+// Allocate and initialize a camera context. Returns NULL on allocation failure.
+homekit_camera_t *homekit_camera_new(
+        const homekit_camera_config_t *config,
+        const homekit_camera_callbacks_t *callbacks,
+        void *context
+        );
+
+void homekit_camera_free(homekit_camera_t *camera);
+
+// Wire the module's getters/setters onto the four TLV8 characteristics of a
+// Camera RTP Stream Management service. Pass the characteristics you declared
+// with the HOMEKIT_DECLARE_CHARACTERISTIC_* macros. `streaming_status` is
+// optional (may be NULL) but recommended.
+//
+// Returns 0 on success.
+int homekit_camera_bind(
+        homekit_camera_t *camera,
+        homekit_characteristic_t *supported_video,
+        homekit_characteristic_t *supported_audio,
+        homekit_characteristic_t *supported_rtp,
+        homekit_characteristic_t *setup_endpoints,
+        homekit_characteristic_t *selected_config,
+        homekit_characteristic_t *streaming_status
+        );
+
+// Update and notify the Streaming Status characteristic.
+void homekit_camera_set_status(homekit_camera_t *camera, homekit_camera_streaming_status_t status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __HOMEKIT_CAMERA_H__

--- a/src/camera.c
+++ b/src/camera.c
@@ -1,0 +1,546 @@
+/**
+
+   Copyright 2026 Achim Pieters | StudioPieters®
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   for more information visit https://www.studiopieters.nl
+
+ **/
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <homekit/camera.h>
+#include <homekit/characteristics.h>
+#include <homekit/tlv.h>
+
+#include "port.h"
+#include "debug.h"
+
+// ---------------------------------------------------------------------------
+// HAP TLV type constants (HAP-R2, Camera RTP Stream Management)
+// ---------------------------------------------------------------------------
+
+// Supported Video Stream Configuration
+enum {
+        VIDEO_CONFIG_CODEC = 1,
+};
+enum {
+        VIDEO_CODEC_TYPE = 1,
+        VIDEO_CODEC_PARAMS = 2,
+        VIDEO_CODEC_ATTRIBUTES = 3,
+};
+enum {
+        VIDEO_CODEC_PARAM_PROFILE = 1,
+        VIDEO_CODEC_PARAM_LEVEL = 2,
+        VIDEO_CODEC_PARAM_PACKETIZATION = 3,
+};
+enum {
+        VIDEO_ATTR_WIDTH = 1,
+        VIDEO_ATTR_HEIGHT = 2,
+        VIDEO_ATTR_FPS = 3,
+};
+
+// Supported Audio Stream Configuration
+enum {
+        AUDIO_CONFIG_CODEC = 1,
+        AUDIO_CONFIG_COMFORT_NOISE = 2,
+};
+enum {
+        AUDIO_CODEC_TYPE = 1,
+        AUDIO_CODEC_PARAMS = 2,
+};
+enum {
+        AUDIO_CODEC_PARAM_CHANNELS = 1,
+        AUDIO_CODEC_PARAM_BITRATE = 2,
+        AUDIO_CODEC_PARAM_SAMPLERATE = 3,
+        AUDIO_CODEC_PARAM_RTP_TIME = 4,
+};
+
+// Supported RTP Configuration
+enum {
+        RTP_CONFIG_SRTP_CRYPTO_SUITE = 2,
+};
+
+// Setup Endpoints
+enum {
+        SETUP_SESSION_ID = 1,
+        SETUP_STATUS = 2,            // (response only)
+        SETUP_ADDRESS = 3,
+        SETUP_SRTP_VIDEO = 4,
+        SETUP_SRTP_AUDIO = 5,
+        SETUP_SSRC_VIDEO = 6,        // (response only)
+        SETUP_SSRC_AUDIO = 7,        // (response only)
+};
+enum {
+        ADDRESS_IP_VERSION = 1,
+        ADDRESS_IP = 2,
+        ADDRESS_VIDEO_RTP_PORT = 3,
+        ADDRESS_AUDIO_RTP_PORT = 4,
+};
+enum {
+        SRTP_CRYPTO_SUITE = 1,
+        SRTP_MASTER_KEY = 2,
+        SRTP_MASTER_SALT = 3,
+};
+
+// Selected RTP Stream Configuration
+enum {
+        SELECTED_SESSION_CONTROL = 1,
+        SELECTED_VIDEO_PARAMS = 2,
+        SELECTED_AUDIO_PARAMS = 3,
+};
+enum {
+        SESSION_CONTROL_ID = 1,
+        SESSION_CONTROL_COMMAND = 2,
+};
+enum {
+        SELECTED_VIDEO_RTP_PARAMS = 4,
+};
+enum {
+        VIDEO_RTP_PAYLOAD_TYPE = 1,
+        VIDEO_RTP_SSRC = 2,
+        VIDEO_RTP_MAX_BITRATE = 3,
+};
+
+#define SETUP_STATUS_SUCCESS 0
+#define SETUP_STATUS_BUSY    1
+#define SETUP_STATUS_ERROR   2
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+homekit_camera_t *homekit_camera_new(
+        const homekit_camera_config_t *config,
+        const homekit_camera_callbacks_t *callbacks,
+        void *context
+        ) {
+        if (!config)
+                return NULL;
+
+        homekit_camera_t *camera = calloc(1, sizeof(homekit_camera_t));
+        if (!camera)
+                return NULL;
+
+        camera->config = *config;
+        if (callbacks)
+                camera->callbacks = *callbacks;
+        camera->context = context;
+        camera->status = homekit_camera_streaming_status_available;
+        camera->last_setup_status = SETUP_STATUS_SUCCESS;
+
+        return camera;
+}
+
+void homekit_camera_free(homekit_camera_t *camera) {
+        free(camera);
+}
+
+// ---------------------------------------------------------------------------
+// Supported configuration builders
+// ---------------------------------------------------------------------------
+
+static tlv_values_t *build_supported_video(const homekit_camera_config_t *c) {
+        tlv_values_t *root = tlv_new();
+        if (!root)
+                return NULL;
+
+        tlv_values_t *codec = tlv_new();
+        if (!codec) {
+                tlv_free(root);
+                return NULL;
+        }
+
+        tlv_add_integer_value(codec, VIDEO_CODEC_TYPE, 1, homekit_camera_video_codec_h264);
+
+        for (size_t i = 0; i < c->h264_param_count; i++) {
+                tlv_values_t *params = tlv_new();
+                if (!params) continue;
+                tlv_add_integer_value(params, VIDEO_CODEC_PARAM_PROFILE, 1, c->h264_params[i].profile);
+                tlv_add_integer_value(params, VIDEO_CODEC_PARAM_LEVEL, 1, c->h264_params[i].level);
+                tlv_add_integer_value(params, VIDEO_CODEC_PARAM_PACKETIZATION, 1, 0); // non-interleaved
+                tlv_add_tlv_value(codec, VIDEO_CODEC_PARAMS, params);
+                tlv_free(params);
+        }
+
+        for (size_t i = 0; i < c->attribute_count; i++) {
+                tlv_values_t *attr = tlv_new();
+                if (!attr) continue;
+                tlv_add_integer_value(attr, VIDEO_ATTR_WIDTH, 2, c->attributes[i].width);
+                tlv_add_integer_value(attr, VIDEO_ATTR_HEIGHT, 2, c->attributes[i].height);
+                tlv_add_integer_value(attr, VIDEO_ATTR_FPS, 1, c->attributes[i].fps);
+                tlv_add_tlv_value(codec, VIDEO_CODEC_ATTRIBUTES, attr);
+                tlv_free(attr);
+        }
+
+        tlv_add_tlv_value(root, VIDEO_CONFIG_CODEC, codec);
+        tlv_free(codec);
+        return root;
+}
+
+static tlv_values_t *build_supported_audio(const homekit_camera_config_t *c) {
+        tlv_values_t *root = tlv_new();
+        if (!root)
+                return NULL;
+
+        for (size_t i = 0; i < c->audio_count; i++) {
+                tlv_values_t *codec = tlv_new();
+                if (!codec) continue;
+                tlv_add_integer_value(codec, AUDIO_CODEC_TYPE, 1, c->audio[i].codec);
+
+                tlv_values_t *params = tlv_new();
+                if (params) {
+                        tlv_add_integer_value(params, AUDIO_CODEC_PARAM_CHANNELS, 1,
+                                              c->audio[i].channels ? c->audio[i].channels : 1);
+                        tlv_add_integer_value(params, AUDIO_CODEC_PARAM_BITRATE, 1,
+                                              c->audio[i].variable_bitrate ? 0 : 1);
+                        tlv_add_integer_value(params, AUDIO_CODEC_PARAM_SAMPLERATE, 1, c->audio[i].sample_rate);
+                        if (c->audio[i].rtp_time)
+                                tlv_add_integer_value(params, AUDIO_CODEC_PARAM_RTP_TIME, 1, c->audio[i].rtp_time);
+                        tlv_add_tlv_value(codec, AUDIO_CODEC_PARAMS, params);
+                        tlv_free(params);
+                }
+
+                tlv_add_tlv_value(root, AUDIO_CONFIG_CODEC, codec);
+                tlv_free(codec);
+        }
+
+        tlv_add_integer_value(root, AUDIO_CONFIG_COMFORT_NOISE, 1, c->comfort_noise ? 1 : 0);
+        return root;
+}
+
+static tlv_values_t *build_supported_rtp(const homekit_camera_config_t *c) {
+        tlv_values_t *root = tlv_new();
+        if (!root)
+                return NULL;
+
+        size_t n = c->srtp_suite_count;
+        if (n == 0) {
+                // Default: advertise the mandatory AES-128 suite.
+                tlv_add_integer_value(root, RTP_CONFIG_SRTP_CRYPTO_SUITE, 1,
+                                      homekit_camera_srtp_crypto_aes_cm_128_hmac_sha1_80);
+                return root;
+        }
+        for (size_t i = 0; i < n; i++)
+                tlv_add_integer_value(root, RTP_CONFIG_SRTP_CRYPTO_SUITE, 1, c->srtp_suites[i]);
+        return root;
+}
+
+static tlv_values_t *build_streaming_status(homekit_camera_streaming_status_t status) {
+        tlv_values_t *root = tlv_new();
+        if (!root)
+                return NULL;
+        tlv_add_integer_value(root, 1 /* status */, 1, status);
+        return root;
+}
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+#define CAMERA_OF(ch) ((homekit_camera_t *)(ch)->context)
+
+static homekit_value_t get_supported_video(const homekit_characteristic_t *ch) {
+        return HOMEKIT_TLV(build_supported_video(&CAMERA_OF(ch)->config));
+}
+
+static homekit_value_t get_supported_audio(const homekit_characteristic_t *ch) {
+        return HOMEKIT_TLV(build_supported_audio(&CAMERA_OF(ch)->config));
+}
+
+static homekit_value_t get_supported_rtp(const homekit_characteristic_t *ch) {
+        return HOMEKIT_TLV(build_supported_rtp(&CAMERA_OF(ch)->config));
+}
+
+static homekit_value_t get_streaming_status(const homekit_characteristic_t *ch) {
+        return HOMEKIT_TLV(build_streaming_status(CAMERA_OF(ch)->status));
+}
+
+// ---------------------------------------------------------------------------
+// Setup Endpoints
+// ---------------------------------------------------------------------------
+
+static void parse_srtp_params(tlv_values_t *t, homekit_camera_srtp_params_t *out) {
+        memset(out, 0, sizeof(*out));
+        out->crypto_suite = tlv_get_integer_value(t, SRTP_CRYPTO_SUITE, homekit_camera_srtp_crypto_none);
+
+        tlv_t *key = tlv_get_value(t, SRTP_MASTER_KEY);
+        if (key && key->size <= sizeof(out->master_key)) {
+                memcpy(out->master_key, key->value, key->size);
+                out->master_key_size = key->size;
+        }
+        tlv_t *salt = tlv_get_value(t, SRTP_MASTER_SALT);
+        if (salt && salt->size <= sizeof(out->master_salt)) {
+                memcpy(out->master_salt, salt->value, salt->size);
+                out->master_salt_size = salt->size;
+        }
+}
+
+static void parse_address(tlv_values_t *t, homekit_camera_address_t *out) {
+        memset(out, 0, sizeof(*out));
+        out->ip_version = tlv_get_integer_value(t, ADDRESS_IP_VERSION, 0);
+        tlv_t *ip = tlv_get_value(t, ADDRESS_IP);
+        if (ip && ip->size < sizeof(out->ip_address)) {
+                memcpy(out->ip_address, ip->value, ip->size);
+                out->ip_address[ip->size] = 0;
+        }
+        out->video_port = tlv_get_integer_value(t, ADDRESS_VIDEO_RTP_PORT, 0);
+        out->audio_port = tlv_get_integer_value(t, ADDRESS_AUDIO_RTP_PORT, 0);
+}
+
+static void generate_srtp(homekit_camera_srtp_params_t *p, uint8_t crypto_suite) {
+        p->crypto_suite = crypto_suite;
+        p->master_key_size =
+                (crypto_suite == homekit_camera_srtp_crypto_aes_256_cm_hmac_sha1_80) ? 32 : 16;
+        p->master_salt_size = 14;
+        homekit_random_fill(p->master_key, p->master_key_size);
+        homekit_random_fill(p->master_salt, p->master_salt_size);
+}
+
+static void add_srtp_tlv(tlv_values_t *parent, uint8_t type, const homekit_camera_srtp_params_t *p) {
+        tlv_values_t *t = tlv_new();
+        if (!t) return;
+        tlv_add_integer_value(t, SRTP_CRYPTO_SUITE, 1, p->crypto_suite);
+        tlv_add_value(t, SRTP_MASTER_KEY, p->master_key, p->master_key_size);
+        tlv_add_value(t, SRTP_MASTER_SALT, p->master_salt, p->master_salt_size);
+        tlv_add_tlv_value(parent, type, t);
+        tlv_free(t);
+}
+
+static void add_address_tlv(tlv_values_t *parent, uint8_t type, const homekit_camera_address_t *a) {
+        tlv_values_t *t = tlv_new();
+        if (!t) return;
+        tlv_add_integer_value(t, ADDRESS_IP_VERSION, 1, a->ip_version);
+        tlv_add_string_value(t, ADDRESS_IP, a->ip_address);
+        tlv_add_integer_value(t, ADDRESS_VIDEO_RTP_PORT, 2, a->video_port);
+        tlv_add_integer_value(t, ADDRESS_AUDIO_RTP_PORT, 2, a->audio_port);
+        tlv_add_tlv_value(parent, type, t);
+        tlv_free(t);
+}
+
+static void setup_endpoints_set(homekit_characteristic_t *ch, const homekit_value_t value) {
+        homekit_camera_t *camera = CAMERA_OF(ch);
+        if (value.format != homekit_format_tlv || !value.tlv_values) {
+                camera->have_setup = true;
+                camera->last_setup_status = SETUP_STATUS_ERROR;
+                return;
+        }
+        tlv_values_t *m = value.tlv_values;
+
+        homekit_camera_session_t *s = &camera->session;
+        memset(s, 0, sizeof(*s));
+
+        tlv_t *sid = tlv_get_value(m, SETUP_SESSION_ID);
+        if (sid && sid->size == sizeof(s->session_id))
+                memcpy(s->session_id, sid->value, sizeof(s->session_id));
+
+        tlv_values_t *addr = tlv_get_tlv_value(m, SETUP_ADDRESS);
+        if (addr) { parse_address(addr, &s->controller); tlv_free(addr); }
+
+        tlv_values_t *vsrtp = tlv_get_tlv_value(m, SETUP_SRTP_VIDEO);
+        if (vsrtp) { parse_srtp_params(vsrtp, &s->controller_video_srtp); tlv_free(vsrtp); }
+
+        tlv_values_t *asrtp = tlv_get_tlv_value(m, SETUP_SRTP_AUDIO);
+        if (asrtp) { parse_srtp_params(asrtp, &s->controller_audio_srtp); tlv_free(asrtp); }
+
+        // Accessory side: generate our SRTP material and SSRCs.
+        generate_srtp(&s->accessory_video_srtp, s->controller_video_srtp.crypto_suite);
+        generate_srtp(&s->accessory_audio_srtp, s->controller_audio_srtp.crypto_suite);
+        homekit_random_fill((uint8_t *)&s->video_ssrc, sizeof(s->video_ssrc));
+        homekit_random_fill((uint8_t *)&s->audio_ssrc, sizeof(s->audio_ssrc));
+
+        // Let the integrator fill the accessory address (local IP + bound ports).
+        uint8_t status = SETUP_STATUS_SUCCESS;
+        if (camera->callbacks.prepare_endpoints) {
+                if (!camera->callbacks.prepare_endpoints(camera, s))
+                        status = SETUP_STATUS_ERROR;
+        } else {
+                s->accessory.ip_version = s->controller.ip_version;
+        }
+
+        camera->have_setup = true;
+        camera->last_setup_status = status;
+}
+
+static homekit_value_t setup_endpoints_get(const homekit_characteristic_t *ch) {
+        homekit_camera_t *camera = CAMERA_OF(ch);
+
+        tlv_values_t *root = tlv_new();
+        if (!root)
+                return HOMEKIT_TLV(NULL);
+
+        if (!camera->have_setup) {
+                return HOMEKIT_TLV(root);
+        }
+
+        homekit_camera_session_t *s = &camera->session;
+        tlv_add_value(root, SETUP_SESSION_ID, s->session_id, sizeof(s->session_id));
+        tlv_add_integer_value(root, SETUP_STATUS, 1, camera->last_setup_status);
+
+        if (camera->last_setup_status == SETUP_STATUS_SUCCESS) {
+                add_address_tlv(root, SETUP_ADDRESS, &s->accessory);
+                add_srtp_tlv(root, SETUP_SRTP_VIDEO, &s->accessory_video_srtp);
+                add_srtp_tlv(root, SETUP_SRTP_AUDIO, &s->accessory_audio_srtp);
+                tlv_add_integer_value(root, SETUP_SSRC_VIDEO, 4, (int)s->video_ssrc);
+                tlv_add_integer_value(root, SETUP_SSRC_AUDIO, 4, (int)s->audio_ssrc);
+        }
+
+        return HOMEKIT_TLV(root);
+}
+
+// ---------------------------------------------------------------------------
+// Selected RTP Stream Configuration
+// ---------------------------------------------------------------------------
+
+static void parse_selected_video(homekit_camera_t *camera, tlv_values_t *vp) {
+        homekit_camera_session_t *s = &camera->session;
+
+        tlv_values_t *attr = tlv_get_tlv_value(vp, VIDEO_CODEC_ATTRIBUTES);
+        if (attr) {
+                s->selected_video.width = tlv_get_integer_value(attr, VIDEO_ATTR_WIDTH, 0);
+                s->selected_video.height = tlv_get_integer_value(attr, VIDEO_ATTR_HEIGHT, 0);
+                s->selected_video.fps = tlv_get_integer_value(attr, VIDEO_ATTR_FPS, 0);
+                tlv_free(attr);
+        }
+
+        tlv_values_t *rtp = tlv_get_tlv_value(vp, SELECTED_VIDEO_RTP_PARAMS);
+        if (rtp) {
+                s->selected_video_rtp_payload_type =
+                        tlv_get_integer_value(rtp, VIDEO_RTP_PAYLOAD_TYPE, 99);
+                s->selected_video_max_bitrate =
+                        tlv_get_integer_value(rtp, VIDEO_RTP_MAX_BITRATE, 0);
+                tlv_free(rtp);
+        }
+        s->has_selected_video = true;
+}
+
+static void selected_config_set(homekit_characteristic_t *ch, const homekit_value_t value) {
+        homekit_camera_t *camera = CAMERA_OF(ch);
+        if (value.format != homekit_format_tlv || !value.tlv_values)
+                return;
+        tlv_values_t *m = value.tlv_values;
+
+        tlv_values_t *ctrl = tlv_get_tlv_value(m, SELECTED_SESSION_CONTROL);
+        if (!ctrl)
+                return;
+
+        uint8_t command = tlv_get_integer_value(ctrl, SESSION_CONTROL_COMMAND,
+                                                 homekit_camera_command_end);
+        tlv_t *sid = tlv_get_value(ctrl, SESSION_CONTROL_ID);
+        uint8_t session_id[16] = {0};
+        if (sid && sid->size == sizeof(session_id))
+                memcpy(session_id, sid->value, sizeof(session_id));
+        tlv_free(ctrl);
+
+        switch (command) {
+        case homekit_camera_command_start:
+        case homekit_camera_command_reconfigure: {
+                tlv_values_t *vp = tlv_get_tlv_value(m, SELECTED_VIDEO_PARAMS);
+                if (vp) { parse_selected_video(camera, vp); tlv_free(vp); }
+
+                if (command == homekit_camera_command_start) {
+                        camera->session_active = true;
+                        homekit_camera_set_status(camera, homekit_camera_streaming_status_in_use);
+                        if (camera->callbacks.on_stream_start)
+                                camera->callbacks.on_stream_start(camera, &camera->session);
+                } else {
+                        if (camera->callbacks.on_stream_reconfigure)
+                                camera->callbacks.on_stream_reconfigure(camera, &camera->session);
+                }
+                break;
+        }
+        case homekit_camera_command_suspend:
+                if (camera->callbacks.on_stream_suspend)
+                        camera->callbacks.on_stream_suspend(camera, session_id);
+                break;
+        case homekit_camera_command_resume:
+                if (camera->callbacks.on_stream_resume)
+                        camera->callbacks.on_stream_resume(camera, session_id);
+                break;
+        case homekit_camera_command_end:
+        default:
+                camera->session_active = false;
+                if (camera->callbacks.on_stream_end)
+                        camera->callbacks.on_stream_end(camera, session_id);
+                homekit_camera_set_status(camera, homekit_camera_streaming_status_available);
+                break;
+        }
+}
+
+static homekit_value_t selected_config_get(const homekit_characteristic_t *ch) {
+        (void)ch;
+        // The Selected RTP Stream Configuration read returns the last selection;
+        // an empty TLV is acceptable when nothing is selected.
+        return HOMEKIT_TLV(tlv_new());
+}
+
+// ---------------------------------------------------------------------------
+// Binding
+// ---------------------------------------------------------------------------
+
+int homekit_camera_bind(
+        homekit_camera_t *camera,
+        homekit_characteristic_t *supported_video,
+        homekit_characteristic_t *supported_audio,
+        homekit_characteristic_t *supported_rtp,
+        homekit_characteristic_t *setup_endpoints,
+        homekit_characteristic_t *selected_config,
+        homekit_characteristic_t *streaming_status
+        ) {
+        if (!camera || !supported_video || !supported_audio || !supported_rtp ||
+            !setup_endpoints || !selected_config)
+                return -1;
+
+        supported_video->context = camera;
+        supported_video->getter_ex = get_supported_video;
+
+        supported_audio->context = camera;
+        supported_audio->getter_ex = get_supported_audio;
+
+        supported_rtp->context = camera;
+        supported_rtp->getter_ex = get_supported_rtp;
+
+        setup_endpoints->context = camera;
+        setup_endpoints->getter_ex = setup_endpoints_get;
+        setup_endpoints->setter_ex = setup_endpoints_set;
+
+        selected_config->context = camera;
+        selected_config->getter_ex = selected_config_get;
+        selected_config->setter_ex = selected_config_set;
+
+        if (streaming_status) {
+                streaming_status->context = camera;
+                streaming_status->getter_ex = get_streaming_status;
+                camera->ch_streaming_status = streaming_status;
+        }
+
+        return 0;
+}
+
+void homekit_camera_set_status(homekit_camera_t *camera, homekit_camera_streaming_status_t status) {
+        camera->status = status;
+        if (camera->ch_streaming_status) {
+                // Notify subscribers with a freshly-built TLV value.
+                homekit_characteristic_notify(
+                        camera->ch_streaming_status,
+                        HOMEKIT_TLV(build_streaming_status(status))
+                        );
+        }
+}

--- a/tests/host/test_camera.c
+++ b/tests/host/test_camera.c
@@ -1,0 +1,231 @@
+// Host regression tests for the HomeKit camera protocol layer (src/camera.c).
+// Platform dependencies are stubbed so the TLV state machine can be exercised
+// on the host under ASan/UBSan.
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <homekit/camera.h>
+#include <homekit/tlv.h>
+
+// ---- stubs for platform symbols referenced by camera.c ----
+void homekit_characteristic_notify(homekit_characteristic_t *ch, const homekit_value_t value) {
+    (void)ch;
+    // The server would free a non-static tlv value; mirror that so ASan is happy.
+    homekit_value_t v = value;
+    homekit_value_destruct(&v);
+}
+uint32_t homekit_random(void) { return 0xA5A5A5A5u; }
+void homekit_random_fill(uint8_t *data, size_t size) {
+    for (size_t i = 0; i < size; i++) data[i] = (uint8_t)(i * 7 + 3);
+}
+
+static int start_calls = 0;
+static int end_calls = 0;
+static homekit_camera_session_t last_started;
+
+static bool prepare_endpoints(homekit_camera_t *c, homekit_camera_session_t *s) {
+    (void)c;
+    s->accessory.ip_version = 0;
+    snprintf(s->accessory.ip_address, sizeof(s->accessory.ip_address), "192.168.1.50");
+    s->accessory.video_port = 6000;
+    s->accessory.audio_port = 6002;
+    return true;
+}
+static void on_start(homekit_camera_t *c, const homekit_camera_session_t *s) {
+    (void)c; start_calls++; last_started = *s;
+}
+static void on_end(homekit_camera_t *c, const uint8_t id[16]) { (void)c; (void)id; end_calls++; }
+
+static homekit_camera_config_t make_config(void) {
+    homekit_camera_config_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.h264_params[0] = (homekit_camera_h264_param_t){
+        homekit_camera_h264_profile_main, homekit_camera_h264_level_4_0};
+    cfg.h264_param_count = 1;
+    cfg.attributes[0] = (homekit_camera_video_attributes_t){1920, 1080, 30};
+    cfg.attributes[1] = (homekit_camera_video_attributes_t){1280, 720, 30};
+    cfg.attribute_count = 2;
+    cfg.audio[0] = (homekit_camera_audio_config_t){
+        homekit_camera_audio_codec_opus, 1, homekit_camera_audio_sample_rate_16khz, 20, true};
+    cfg.audio_count = 1;
+    cfg.srtp_suites[0] = homekit_camera_srtp_crypto_aes_cm_128_hmac_sha1_80;
+    cfg.srtp_suite_count = 1;
+    return cfg;
+}
+
+static homekit_characteristic_t mk_char(void) {
+    homekit_characteristic_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.format = homekit_format_tlv;
+    return ch;
+}
+
+static void test_supported_config(void) {
+    homekit_camera_config_t cfg = make_config();
+    homekit_camera_t *cam = homekit_camera_new(&cfg, NULL, NULL);
+    assert(cam);
+
+    homekit_characteristic_t sv = mk_char(), sa = mk_char(), sr = mk_char(),
+                             se = mk_char(), sc = mk_char(), ss = mk_char();
+    assert(homekit_camera_bind(cam, &sv, &sa, &sr, &se, &sc, &ss) == 0);
+
+    // Supported video must contain a codec config (type 1) that decodes and
+    // carries two video attributes.
+    homekit_value_t v = sv.getter_ex(&sv);
+    assert(v.format == homekit_format_tlv && v.tlv_values);
+    tlv_values_t *codec = tlv_get_tlv_value(v.tlv_values, 1);
+    assert(codec);
+    int attr_count = 0;
+    for (tlv_t *t = codec->head; t; t = t->next)
+        if (t->type == 3 /* attributes */) attr_count++;
+    assert(attr_count == 2);
+    tlv_free(codec);
+    homekit_value_destruct(&v);
+
+    // Supported RTP advertises the AES-128 suite.
+    homekit_value_t r = sr.getter_ex(&sr);
+    assert(tlv_get_integer_value(r.tlv_values, 2, -1) ==
+           homekit_camera_srtp_crypto_aes_cm_128_hmac_sha1_80);
+    homekit_value_destruct(&r);
+
+    homekit_camera_free(cam);
+}
+
+static void test_setup_endpoints_roundtrip(void) {
+    homekit_camera_config_t cfg = make_config();
+    homekit_camera_callbacks_t cb = {0};
+    cb.prepare_endpoints = prepare_endpoints;
+    homekit_camera_t *cam = homekit_camera_new(&cfg, &cb, NULL);
+    assert(cam);
+
+    homekit_characteristic_t sv = mk_char(), sa = mk_char(), sr = mk_char(),
+                             se = mk_char(), sc = mk_char(), ss = mk_char();
+    assert(homekit_camera_bind(cam, &sv, &sa, &sr, &se, &sc, &ss) == 0);
+
+    // Build a controller Setup Endpoints request.
+    tlv_values_t *req = tlv_new();
+    uint8_t sid[16];
+    for (int i = 0; i < 16; i++) sid[i] = (uint8_t)i;
+    tlv_add_value(req, 1 /* session id */, sid, sizeof(sid));
+
+    tlv_values_t *addr = tlv_new();
+    tlv_add_integer_value(addr, 1, 1, 0);            // IPv4
+    tlv_add_string_value(addr, 2, "10.0.0.9");       // controller IP
+    tlv_add_integer_value(addr, 3, 2, 5000);         // video port
+    tlv_add_integer_value(addr, 4, 2, 5002);         // audio port
+    tlv_add_tlv_value(req, 3 /* address */, addr);
+    tlv_free(addr);
+
+    uint8_t key[16], salt[14];
+    memset(key, 0xAB, sizeof(key));
+    memset(salt, 0xCD, sizeof(salt));
+    tlv_values_t *vsrtp = tlv_new();
+    tlv_add_integer_value(vsrtp, 1, 1, 0);           // AES-128
+    tlv_add_value(vsrtp, 2, key, sizeof(key));
+    tlv_add_value(vsrtp, 3, salt, sizeof(salt));
+    tlv_add_tlv_value(req, 4 /* srtp video */, vsrtp);
+    tlv_free(vsrtp);
+
+    se.setter_ex(&se, HOMEKIT_TLV(req));
+    homekit_value_t reqv = HOMEKIT_TLV(req);
+    homekit_value_destruct(&reqv);
+
+    // Read back the accessory response.
+    homekit_value_t resp = se.getter_ex(&se);
+    assert(resp.format == homekit_format_tlv && resp.tlv_values);
+
+    tlv_t *rsid = tlv_get_value(resp.tlv_values, 1);
+    assert(rsid && rsid->size == 16 && memcmp(rsid->value, sid, 16) == 0); // echoed
+    assert(tlv_get_integer_value(resp.tlv_values, 2, -1) == 0);            // status success
+
+    tlv_values_t *raddr = tlv_get_tlv_value(resp.tlv_values, 3);
+    assert(raddr);
+    tlv_t *ip = tlv_get_value(raddr, 2);
+    assert(ip && ip->size == strlen("192.168.1.50") &&
+           memcmp(ip->value, "192.168.1.50", ip->size) == 0);             // from prepare cb
+    assert(tlv_get_integer_value(raddr, 3, 0) == 6000);
+    tlv_free(raddr);
+
+    tlv_values_t *rv = tlv_get_tlv_value(resp.tlv_values, 4);
+    assert(rv);
+    tlv_t *rkey = tlv_get_value(rv, 2);
+    assert(rkey && rkey->size == 16); // accessory generated a 16-byte AES-128 key
+    tlv_free(rv);
+
+    assert(tlv_get_value(resp.tlv_values, 6)); // video SSRC present
+    homekit_value_destruct(&resp);
+
+    homekit_camera_free(cam);
+}
+
+static void test_selected_config_start(void) {
+    homekit_camera_config_t cfg = make_config();
+    homekit_camera_callbacks_t cb = {0};
+    cb.on_stream_start = on_start;
+    cb.on_stream_end = on_end;
+    homekit_camera_t *cam = homekit_camera_new(&cfg, &cb, NULL);
+    assert(cam);
+
+    homekit_characteristic_t sv = mk_char(), sa = mk_char(), sr = mk_char(),
+                             se = mk_char(), sc = mk_char(), ss = mk_char();
+    assert(homekit_camera_bind(cam, &sv, &sa, &sr, &se, &sc, &ss) == 0);
+
+    start_calls = end_calls = 0;
+
+    // Selected RTP Stream Configuration: Start
+    tlv_values_t *sel = tlv_new();
+    tlv_values_t *ctrl = tlv_new();
+    uint8_t sid[16] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16};
+    tlv_add_value(ctrl, 1 /* session id */, sid, sizeof(sid));
+    tlv_add_integer_value(ctrl, 2 /* command */, 1, homekit_camera_command_start);
+    tlv_add_tlv_value(sel, 1 /* session control */, ctrl);
+    tlv_free(ctrl);
+
+    tlv_values_t *vp = tlv_new();
+    tlv_values_t *attr = tlv_new();
+    tlv_add_integer_value(attr, 1, 2, 1280);
+    tlv_add_integer_value(attr, 2, 2, 720);
+    tlv_add_integer_value(attr, 3, 1, 30);
+    tlv_add_tlv_value(vp, 3 /* attributes */, attr);
+    tlv_free(attr);
+    tlv_add_tlv_value(sel, 2 /* video params */, vp);
+    tlv_free(vp);
+
+    sc.setter_ex(&sc, HOMEKIT_TLV(sel));
+    homekit_value_t selv = HOMEKIT_TLV(sel);
+    homekit_value_destruct(&selv);
+
+    assert(start_calls == 1);
+    assert(cam->session_active);
+    assert(cam->status == homekit_camera_streaming_status_in_use);
+    assert(last_started.selected_video.width == 1280 && last_started.selected_video.height == 720);
+
+    // End
+    tlv_values_t *sel2 = tlv_new();
+    tlv_values_t *ctrl2 = tlv_new();
+    tlv_add_value(ctrl2, 1, sid, sizeof(sid));
+    tlv_add_integer_value(ctrl2, 2, 1, homekit_camera_command_end);
+    tlv_add_tlv_value(sel2, 1, ctrl2);
+    tlv_free(ctrl2);
+    sc.setter_ex(&sc, HOMEKIT_TLV(sel2));
+    homekit_value_t sel2v = HOMEKIT_TLV(sel2);
+    homekit_value_destruct(&sel2v);
+
+    assert(end_calls == 1);
+    assert(!cam->session_active);
+    assert(cam->status == homekit_camera_streaming_status_available);
+
+    homekit_camera_free(cam);
+}
+
+int main(void) {
+    test_supported_config();
+    test_setup_endpoints_roundtrip();
+    test_selected_config_start();
+    puts("camera tests passed");
+    return 0;
+}


### PR DESCRIPTION
Voegt de **HAP protocol-laag voor HomeKit IP-camera's** toe (nieuwe, draagbare module `include/homekit/camera.h` + `src/camera.c`).

## Wat dit doet
- Supported **Video/Audio/RTP Stream Configuration** TLV8-builders
- **Setup Endpoints**: parse controller-adres + SRTP-params, genereer accessoire-SRTP-sleutel/salt + SSRCs, bouw respons (accessoire-endpoint via `prepare_endpoints`-callback)
- **Selected RTP Stream Configuration**: Start/End/Suspend/Resume/Reconfigure → integrator-callbacks
- **Streaming Status** characteristic met notificaties
- API: `homekit_camera_new` / `_bind` / `_set_status`
- Snapshots blijven via de bestaande `on_resource`-hook

## Bewust buiten scope (eerlijk)
Dit is **alleen de protocol-laag**. Realtime **H.264**/audio-encoding, RTP-packetisatie en **SRTP**-encryptie (het media-vlak) blijven de verantwoordelijkheid van de integrator en vereisen geschikte hardware (bv. ESP32-P4 of externe encoder; klassieke ESP32/S3 heeft geen H.264-encoder). **HomeKit Secure Video** valt buiten scope. Officiële HAP-compliance is MFi/Apple-gecertificeerd en kan niet via code alleen worden verkregen.

## Build & tests
- `camera.c` wordt standaard meegebouwd (CMake `SRC_DIRS` / `component.mk`); inert tenzij `homekit_camera_new()` wordt aangeroepen.
- `tests/host/test_camera.c`: supported-config-builders, Setup-Endpoints round-trip en Selected-config Start/End onder ASan/UBSan; toegevoegd aan de host-regression-workflow (gnu11 omdat de publieke headers GNU-extensies gebruiken).
- Documentatie + integratiegids in `docs/CAMERA.md`.

> Stapelt op #59 (audit round 2); PR-base staat daarom op `audit-fixes-round2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)