### PR TITLE
Fix ESP-IDF CI: drop invalid 'idf.py build -v'

### DIFF
--- a/.github/workflows/esp-idf-compat.yml
+++ b/.github/workflows/esp-idf-compat.yml
@@ -97,7 +97,7 @@ jobs:
           idf.py --version
           idf.py set-target "${{ matrix.target }}"
           for attempt in 1 2 3; do
-            if idf.py build -v; then
+            if idf.py build; then
               break
             fi
             if [[ "${attempt}" -eq 3 ]]; then


### PR DESCRIPTION
The matrix build step used `idf.py build -v`; `-v` is not a valid option of the build subcommand (idf.py: 'No such option: -v'), so all 13 jobs failed their build retries. Latent bug revealed after the workflow-file fix let the workflow start. Use plain `idf.py build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)