### PR TITLE
CI: align ESP-IDF matrix with declared support (v5.x only)

### DIFF
--- a/.github/workflows/esp-idf-compat.yml
+++ b/.github/workflows/esp-idf-compat.yml
@@ -35,20 +35,6 @@ jobs:
             target: "esp32c3"
           - idf: "release/v5.3"
             target: "esp32c6"
-          # Latest major line (ESP-IDF v6.0)
-          - idf: "release/v6.0"
-            target: "esp32"
-          - idf: "release/v6.0"
-            target: "esp32s2"
-          - idf: "release/v6.0"
-            target: "esp32s3"
-          - idf: "release/v6.0"
-            target: "esp32c3"
-          - idf: "release/v6.0"
-            target: "esp32c5"
-          - idf: "release/v6.0"
-            target: "esp32c6"
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
v6.0 jobs failed at dependency version-solving because the manifest declares idf >=5.0,<6.0. All v5.3 targets build green. Drop v6.0 rows so CI matches declared support; full 6.0 support is a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)