### PR TITLE
Camera streaming: tested SRTP + H.264 RTP media layer

### DIFF
--- a/.github/workflows/host-regression-tests.yml
+++ b/.github/workflows/host-regression-tests.yml
@@ -48,3 +48,19 @@ jobs:
             -o /tmp/homekit-camera-tests
           ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1 \
             /tmp/homekit-camera-tests
+
+      - name: Compile and run SRTP / RTP tests
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # SRTP crypto + H.264 RTP packetizer: validated against published
+          # test vectors (FIPS-197, RFC 2202, RFC 3711) plus a protect/decrypt
+          # round-trip. Pure ISO C11.
+          gcc -std=c11 -D_POSIX_C_SOURCE=200809L \
+            -Wall -Wextra -Werror -pedantic -Wno-strict-prototypes \
+            -fsanitize=address,undefined -fno-omit-frame-pointer \
+            -Iinclude -Isrc \
+            tests/host/test_srtp.c \
+            -o /tmp/homekit-srtp-tests
+          ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1 \
+            /tmp/homekit-srtp-tests

--- a/docs/CAMERA.md
+++ b/docs/CAMERA.md
@@ -122,3 +122,78 @@ void on_resource(const char *body, size_t body_size) {
 
 This module gets you a controller that successfully negotiates a session; steps
 1–5 (the media plane) are hardware/codec specific and are your responsibility.
+
+## Live streaming: RTP + SRTP (built-in, tested)
+
+The repository now ships the media-plane primitives needed to send encoded
+video to a controller:
+
+- `include/homekit/srtp.h` / `src/srtp.c` — SRTP sender for the mandatory
+  `SRTP_AES_CM_128_HMAC_SHA1_80` suite. Self-contained (AES-128 / SHA-1 /
+  HMAC-SHA1), validated on the host against **FIPS-197**, **RFC 2202** and the
+  **RFC 3711 §B.3** key-derivation test vectors.
+- `include/homekit/rtp.h` / `src/rtp.c` — H.264 RTP packetizer (RFC 6184:
+  single-NAL and FU-A fragmentation) that SRTP-protects each packet. Validated
+  by a protect → decrypt → NAL-reassembly round-trip in CI.
+
+You still provide the **H.264 source** (`esp_h264` — hardware on ESP32-P4,
+software on ESP32-S3) and the UDP socket. The wiring from `on_stream_start`:
+
+```c
+#include <homekit/rtp.h>
+#include <lwip/sockets.h>
+
+static int           g_sock = -1;
+static struct sockaddr_in g_dest;
+static homekit_rtp_h264_t g_rtp;
+static uint8_t       g_rtp_buf[1378];   // SRTP packet scratch (MTU-sized)
+
+static void udp_send(void *user, const uint8_t *pkt, size_t len) {
+    (void)user;
+    sendto(g_sock, pkt, len, 0, (struct sockaddr *)&g_dest, sizeof(g_dest));
+}
+
+static void on_stream_start(homekit_camera_t *cam, const homekit_camera_session_t *s) {
+    // Destination = controller's video RTP endpoint.
+    g_sock = socket(AF_INET, SOCK_DGRAM, 0);
+    memset(&g_dest, 0, sizeof(g_dest));
+    g_dest.sin_family = AF_INET;
+    g_dest.sin_port   = htons(s->controller.video_port);
+    inet_pton(AF_INET, s->controller.ip_address, &g_dest.sin_addr);
+
+    // The accessory sends video to the controller; encrypt it with the SRTP key
+    // the controller provided for that stream (controller_video_srtp), and use
+    // the accessory video SSRC negotiated during Setup Endpoints.
+    homekit_rtp_h264_init(&g_rtp,
+        s->controller_video_srtp.master_key,
+        s->controller_video_srtp.master_salt,
+        s->video_ssrc,
+        s->selected_video_rtp_payload_type,
+        sizeof(g_rtp_buf), g_rtp_buf,
+        udp_send, NULL);
+
+    // ... start your esp_h264 encoder at s->selected_video.{width,height,fps}
+    //     and s->selected_video_max_bitrate, then in your media task: ...
+}
+
+// Called from your media task for each encoded access unit (Annex-B from
+// esp_h264). ts90k is the capture time in 90 kHz units (RTP video clock).
+static void on_encoded_frame(const uint8_t *au, size_t au_len, uint32_t ts90k) {
+    homekit_rtp_h264_send(&g_rtp, au, au_len, ts90k);
+}
+```
+
+> **SRTP key direction:** HomeKit's Setup Endpoints exchanges SRTP keys for both
+> directions. This example encrypts the outgoing video with
+> `controller_video_srtp` (the key the controller supplied for the stream it
+> receives). The accessory-generated `accessory_*_srtp` keys are for streams the
+> accessory *receives* (e.g. two-way audio). Confirm the exact mapping against
+> your controller during bring-up — the crypto and packetization themselves are
+> covered by the host test vectors.
+
+### What is and isn't verified
+Verified in CI (host): the SRTP crypto (against published vectors) and the
+RTP/FU-A framing (round-trip). **Not** verifiable without hardware + a real
+controller: the camera capture/encode loop, the UDP transport, RTCP feedback,
+and the precise key-direction mapping above. Those are the on-device bring-up
+steps.

--- a/include/homekit/rtp.h
+++ b/include/homekit/rtp.h
@@ -1,0 +1,53 @@
+#ifndef __HOMEKIT_RTP_H__
+#define __HOMEKIT_RTP_H__
+
+// H.264 RTP packetizer (RFC 6184) with SRTP protection, for sending an
+// accessory's encoded video to a HomeKit controller. Takes an H.264 access
+// unit in Annex-B byte-stream form (NAL units separated by 0x000001 / 0x00000001
+// start codes, as produced by esp_h264), splits it into RTP packets
+// (single-NAL or FU-A fragmentation to respect the MTU), SRTP-protects each
+// packet, and hands it to a send callback (typically a UDP sendto()).
+
+#include <stdint.h>
+#include <stddef.h>
+#include <homekit/srtp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Called for every fully-built SRTP packet. `pkt`/`len` are owned by the
+// packetizer (valid only during the call); copy if needed.
+typedef void (*homekit_rtp_send_fn)(void *user, const uint8_t *pkt, size_t len);
+
+typedef struct {
+        homekit_srtp_t      srtp;
+        uint32_t            ssrc;
+        uint8_t             payload_type;   // dynamic PT negotiated for the stream
+        uint16_t            seq;
+        size_t              mtu;            // max SRTP packet size (e.g. 1378)
+        homekit_rtp_send_fn send;
+        void               *user;
+        uint8_t            *buf;            // scratch buffer of `mtu` bytes
+} homekit_rtp_h264_t;
+
+// Initialize. `buf` must point to at least `mtu` bytes of scratch storage that
+// outlives the packetizer. master_key/master_salt + ssrc come from the
+// negotiated camera session; payload_type from the Selected RTP config.
+// Returns 0 on success.
+int homekit_rtp_h264_init(homekit_rtp_h264_t *ctx,
+                          const uint8_t master_key[16], const uint8_t master_salt[14],
+                          uint32_t ssrc, uint8_t payload_type, size_t mtu,
+                          uint8_t *buf,
+                          homekit_rtp_send_fn send, void *user);
+
+// Packetize and send one Annex-B access unit at the given 90 kHz timestamp.
+// Returns the number of RTP packets sent, or < 0 on error.
+int homekit_rtp_h264_send(homekit_rtp_h264_t *ctx,
+                          const uint8_t *au, size_t au_len, uint32_t timestamp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/homekit/srtp.h
+++ b/include/homekit/srtp.h
@@ -1,0 +1,54 @@
+#ifndef __HOMEKIT_SRTP_H__
+#define __HOMEKIT_SRTP_H__
+
+// Minimal SRTP sender for HomeKit camera streaming.
+// Crypto suite: SRTP_AES_CM_128_HMAC_SHA1_80 (the mandatory HomeKit suite).
+//
+// Self-contained (AES-128 / SHA-1 / HMAC-SHA1 implemented in srtp.c), so it is
+// portable and host-testable against published test vectors (FIPS-197,
+// RFC 2202, RFC 3711). It only implements the sender side (protect); that is
+// all an accessory needs to stream video/audio to a controller.
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HOMEKIT_SRTP_MASTER_KEY_SIZE   16
+#define HOMEKIT_SRTP_MASTER_SALT_SIZE  14
+#define HOMEKIT_SRTP_AUTH_TAG_SIZE     10   // 80-bit tag
+
+typedef struct {
+        uint8_t  enc_rk[176];   // expanded AES-128 session encryption round keys
+        uint8_t  auth_key[20];  // session HMAC-SHA1 key
+        uint8_t  salt[14];      // session salt
+        uint32_t ssrc;
+        uint32_t roc;           // rollover counter
+        uint16_t last_seq;
+        int      seq_seen;
+} homekit_srtp_t;
+
+// Initialize the SRTP context for one outgoing stream identified by ssrc.
+// master_key/master_salt come from the negotiated HomeKit camera session.
+// Returns 0 on success.
+int homekit_srtp_init(homekit_srtp_t *ctx,
+                      const uint8_t master_key[HOMEKIT_SRTP_MASTER_KEY_SIZE],
+                      const uint8_t master_salt[HOMEKIT_SRTP_MASTER_SALT_SIZE],
+                      uint32_t ssrc);
+
+// Protect a complete RTP packet in place: encrypts the payload (AES-CM) and
+// appends a 10-byte HMAC-SHA1-80 authentication tag.
+//   pkt      : buffer holding a 12-byte RTP header followed by the payload
+//   pkt_len  : current packet length (header + payload), >= 12
+//   capacity : size of pkt buffer; must be >= pkt_len + 10
+// The packet's SSRC field (bytes 8..11) must equal ctx->ssrc.
+// Returns the new total length (pkt_len + 10) on success, or < 0 on error.
+int homekit_srtp_protect(homekit_srtp_t *ctx, uint8_t *pkt, size_t pkt_len, size_t capacity);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -1,0 +1,166 @@
+/**
+
+   Copyright 2026 Achim Pieters | StudioPieters®
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   for more information visit https://www.studiopieters.nl
+
+ **/
+
+#include <homekit/rtp.h>
+#include <string.h>
+
+#define RTP_HEADER_SIZE 12
+#define FU_A_TYPE 28
+
+int homekit_rtp_h264_init(homekit_rtp_h264_t *ctx,
+                          const uint8_t master_key[16], const uint8_t master_salt[14],
+                          uint32_t ssrc, uint8_t payload_type, size_t mtu,
+                          uint8_t *buf,
+                          homekit_rtp_send_fn send, void *user) {
+        if (!ctx || !buf || !send) return -1;
+        // Need room for RTP header + at least 2 bytes payload + SRTP tag.
+        if (mtu < RTP_HEADER_SIZE + 2 + HOMEKIT_SRTP_AUTH_TAG_SIZE) return -1;
+        if (homekit_srtp_init(&ctx->srtp, master_key, master_salt, ssrc)) return -1;
+        ctx->ssrc = ssrc;
+        ctx->payload_type = payload_type;
+        ctx->seq = 0;
+        ctx->mtu = mtu;
+        ctx->buf = buf;
+        ctx->send = send;
+        ctx->user = user;
+        return 0;
+}
+
+// Find the next Annex-B NAL unit in [p, end). Sets *nal/*nal_len to the NAL
+// (without start code). Returns the pointer just past it, or NULL when done.
+static const uint8_t *next_nal(const uint8_t *p, const uint8_t *end,
+                               const uint8_t **nal, size_t *nal_len) {
+        // skip to a start code (00 00 01 or 00 00 00 01)
+        while (p + 3 <= end) {
+                if (p[0] == 0 && p[1] == 0 && p[2] == 1) { p += 3; break; }
+                if (p + 4 <= end && p[0] == 0 && p[1] == 0 && p[2] == 0 && p[3] == 1) { p += 4; break; }
+                p++;
+        }
+        if (p >= end) return NULL;
+        const uint8_t *start = p;
+        // find the next start code
+        while (p + 3 <= end) {
+                if (p[0] == 0 && p[1] == 0 && p[2] == 1) break;
+                p++;
+        }
+        const uint8_t *stop = (p + 3 <= end) ? p : end;
+        // a 4-byte start code's leading zero belongs to the prefix, not this NAL
+        if (stop > start && stop != end && stop[-1] == 0) stop--;
+        *nal = start;
+        *nal_len = (size_t)(stop - start);
+        return stop;
+}
+
+// Build, protect and send one RTP packet from `payload`. marker sets the M bit.
+static int emit_packet(homekit_rtp_h264_t *ctx, const uint8_t *payload, size_t plen,
+                       uint32_t ts, int marker) {
+        uint8_t *pkt = ctx->buf;
+        size_t cap = ctx->mtu;
+        if (RTP_HEADER_SIZE + plen + HOMEKIT_SRTP_AUTH_TAG_SIZE > cap) return -1;
+
+        pkt[0] = 0x80;                                  // V=2, P=0, X=0, CC=0
+        pkt[1] = (uint8_t)((marker ? 0x80 : 0) | (ctx->payload_type & 0x7f));
+        pkt[2] = (uint8_t)(ctx->seq >> 8);
+        pkt[3] = (uint8_t)(ctx->seq);
+        pkt[4] = (uint8_t)(ts >> 24); pkt[5] = (uint8_t)(ts >> 16);
+        pkt[6] = (uint8_t)(ts >> 8);  pkt[7] = (uint8_t)(ts);
+        pkt[8]  = (uint8_t)(ctx->ssrc >> 24); pkt[9]  = (uint8_t)(ctx->ssrc >> 16);
+        pkt[10] = (uint8_t)(ctx->ssrc >> 8);  pkt[11] = (uint8_t)(ctx->ssrc);
+        memcpy(pkt + RTP_HEADER_SIZE, payload, plen);
+        ctx->seq++;
+
+        int n = homekit_srtp_protect(&ctx->srtp, pkt, RTP_HEADER_SIZE + plen, cap);
+        if (n < 0) return -1;
+        ctx->send(ctx->user, pkt, (size_t)n);
+        return 0;
+}
+
+int homekit_rtp_h264_send(homekit_rtp_h264_t *ctx,
+                          const uint8_t *au, size_t au_len, uint32_t timestamp) {
+        if (!ctx || !au) return -1;
+
+        // Maximum RTP payload that still fits the MTU after header + SRTP tag.
+        size_t max_payload = ctx->mtu - RTP_HEADER_SIZE - HOMEKIT_SRTP_AUTH_TAG_SIZE;
+
+        // Collect NAL units first so we can mark the last packet of the access unit.
+        const uint8_t *p = au, *end = au + au_len;
+        const uint8_t *nals[64]; size_t nlens[64]; int ncount = 0;
+        const uint8_t *nal; size_t nlen;
+        while ((p = next_nal(p, end, &nal, &nlen)) != NULL) {
+                if (nlen == 0) continue;
+                if (ncount < 64) { nals[ncount] = nal; nlens[ncount] = nlen; ncount++; }
+        }
+        if (ncount == 0) return 0;
+
+        int sent = 0;
+        for (int i = 0; i < ncount; i++) {
+                int last_nal = (i == ncount - 1);
+                nal = nals[i]; nlen = nlens[i];
+
+                if (nlen <= max_payload) {
+                        // Single NAL unit packet.
+                        if (emit_packet(ctx, nal, nlen, timestamp, last_nal) < 0) return -1;
+                        sent++;
+                } else {
+                        // FU-A fragmentation.
+                        uint8_t nal_hdr = nal[0];
+                        const uint8_t *data = nal + 1;
+                        size_t remaining = nlen - 1;
+                        size_t frag_max = max_payload - 2;   // 2 bytes FU indicator+header
+                        int first = 1;
+                        while (remaining > 0) {
+                                size_t fsz = remaining > frag_max ? frag_max : remaining;
+                                int is_last_frag = (fsz == remaining);
+                                uint8_t fu_ind = (uint8_t)((nal_hdr & 0xE0) | FU_A_TYPE);
+                                uint8_t fu_hdr = (uint8_t)((first ? 0x80 : 0) |
+                                                           (is_last_frag ? 0x40 : 0) |
+                                                           (nal_hdr & 0x1F));
+                                // Build the FU-A packet (RTP header + FU indicator + FU header
+                                // + fragment) directly in the scratch buffer, then SRTP in place.
+                                uint8_t *pkt = ctx->buf;
+                                pkt[0] = 0x80;
+                                int marker = (last_nal && is_last_frag) ? 0x80 : 0;
+                                pkt[1] = (uint8_t)(marker | (ctx->payload_type & 0x7f));
+                                pkt[2] = (uint8_t)(ctx->seq >> 8);
+                                pkt[3] = (uint8_t)(ctx->seq);
+                                pkt[4] = (uint8_t)(timestamp >> 24); pkt[5] = (uint8_t)(timestamp >> 16);
+                                pkt[6] = (uint8_t)(timestamp >> 8);  pkt[7] = (uint8_t)(timestamp);
+                                pkt[8]  = (uint8_t)(ctx->ssrc >> 24); pkt[9]  = (uint8_t)(ctx->ssrc >> 16);
+                                pkt[10] = (uint8_t)(ctx->ssrc >> 8);  pkt[11] = (uint8_t)(ctx->ssrc);
+                                pkt[12] = fu_ind;
+                                pkt[13] = fu_hdr;
+                                memcpy(pkt + 14, data, fsz);
+                                ctx->seq++;
+                                int n = homekit_srtp_protect(&ctx->srtp, pkt, 14 + fsz, ctx->mtu);
+                                if (n < 0) return -1;
+                                ctx->send(ctx->user, pkt, (size_t)n);
+                                sent++;
+
+                                data += fsz; remaining -= fsz; first = 0;
+                        }
+                }
+        }
+        return sent;
+}

--- a/src/srtp.c
+++ b/src/srtp.c
@@ -1,0 +1,246 @@
+/**
+
+   Copyright 2026 Achim Pieters | StudioPieters®
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   for more information visit https://www.studiopieters.nl
+
+ **/
+
+#include <homekit/srtp.h>
+#include <string.h>
+
+static const uint8_t SBOX[256] = {
+0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,
+0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,
+0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,
+0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,
+0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,
+0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,
+0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,
+0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,
+0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,
+0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,
+0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,
+0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,
+0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,
+0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,
+0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,
+0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16};
+
+static const uint8_t RCON[11] = {0x00,0x01,0x02,0x04,0x08,0x10,0x20,0x40,0x80,0x1b,0x36};
+
+typedef struct { uint8_t rk[176]; } aes128_t;  // 11 round keys * 16 bytes
+
+static void aes128_init(aes128_t *a, const uint8_t key[16]) {
+        memcpy(a->rk, key, 16);
+        for (int i = 4; i < 44; i++) {
+                uint8_t t[4];
+                memcpy(t, a->rk + (i-1)*4, 4);
+                if (i % 4 == 0) {
+                        uint8_t tmp = t[0];
+                        t[0] = SBOX[t[1]] ^ RCON[i/4];
+                        t[1] = SBOX[t[2]];
+                        t[2] = SBOX[t[3]];
+                        t[3] = SBOX[tmp];
+                }
+                for (int j = 0; j < 4; j++)
+                        a->rk[i*4+j] = a->rk[(i-4)*4+j] ^ t[j];
+        }
+}
+
+static uint8_t xtime(uint8_t x) { return (uint8_t)((x<<1) ^ ((x>>7)*0x1b)); }
+static uint8_t mul(uint8_t x, uint8_t y) {
+        uint8_t r = 0;
+        while (y) { if (y&1) r ^= x; x = xtime(x); y >>= 1; }
+        return r;
+}
+
+static void aes128_encrypt(const aes128_t *a, const uint8_t in[16], uint8_t out[16]) {
+        uint8_t s[16];
+        for (int i = 0; i < 16; i++) s[i] = in[i] ^ a->rk[i];
+        for (int round = 1; round <= 10; round++) {
+                uint8_t t[16];
+                for (int i = 0; i < 16; i++) t[i] = SBOX[s[i]];
+                // ShiftRows
+                uint8_t sr[16] = {
+                  t[0],  t[5],  t[10], t[15],
+                  t[4],  t[9],  t[14], t[3],
+                  t[8],  t[13], t[2],  t[7],
+                  t[12], t[1],  t[6],  t[11]};
+                if (round < 10) {
+                        for (int c = 0; c < 4; c++) {
+                                uint8_t *col = sr + c*4;
+                                uint8_t a0=col[0],a1=col[1],a2=col[2],a3=col[3];
+                                col[0]=mul(a0,2)^mul(a1,3)^a2^a3;
+                                col[1]=a0^mul(a1,2)^mul(a2,3)^a3;
+                                col[2]=a0^a1^mul(a2,2)^mul(a3,3);
+                                col[3]=mul(a0,3)^a1^a2^mul(a3,2);
+                        }
+                }
+                for (int i = 0; i < 16; i++) s[i] = sr[i] ^ a->rk[round*16+i];
+        }
+        memcpy(out, s, 16);
+}
+
+// ---------------- SHA-1 ------------------------------------------------------
+typedef struct { uint32_t h[5]; uint64_t len; uint8_t buf[64]; size_t n; } sha1_t;
+static uint32_t rol32(uint32_t x, int c){ return (x<<c)|(x>>(32-c)); }
+static void sha1_block(sha1_t *s, const uint8_t *p) {
+        uint32_t w[80];
+        for (int i=0;i<16;i++) w[i]=((uint32_t)p[i*4]<<24)|((uint32_t)p[i*4+1]<<16)|((uint32_t)p[i*4+2]<<8)|(uint32_t)p[i*4+3];
+        for (int i=16;i<80;i++) w[i]=rol32(w[i-3]^w[i-8]^w[i-14]^w[i-16],1);
+        uint32_t a=s->h[0],b=s->h[1],c=s->h[2],d=s->h[3],e=s->h[4];
+        for (int i=0;i<80;i++){
+                uint32_t f,k;
+                if(i<20){f=(b&c)|((~b)&d);k=0x5A827999;}
+                else if(i<40){f=b^c^d;k=0x6ED9EBA1;}
+                else if(i<60){f=(b&c)|(b&d)|(c&d);k=0x8F1BBCDC;}
+                else {f=b^c^d;k=0xCA62C1D6;}
+                uint32_t t=rol32(a,5)+f+e+k+w[i];
+                e=d;d=c;c=rol32(b,30);b=a;a=t;
+        }
+        s->h[0]+=a;s->h[1]+=b;s->h[2]+=c;s->h[3]+=d;s->h[4]+=e;
+}
+static void sha1_init(sha1_t *s){ s->h[0]=0x67452301;s->h[1]=0xEFCDAB89;s->h[2]=0x98BADCFE;s->h[3]=0x10325476;s->h[4]=0xC3D2E1F0;s->len=0;s->n=0; }
+static void sha1_update(sha1_t *s, const uint8_t *p, size_t len){
+        s->len += len;
+        while (len){ size_t take=64-s->n; if(take>len)take=len; memcpy(s->buf+s->n,p,take); s->n+=take; p+=take; len-=take;
+                if(s->n==64){ sha1_block(s,s->buf); s->n=0; } }
+}
+static void sha1_final(sha1_t *s, uint8_t out[20]){
+        uint64_t bits = s->len*8;
+        uint8_t pad=0x80; sha1_update(s,&pad,1);
+        uint8_t z=0; while(s->n!=56) sha1_update(s,&z,1);
+        uint8_t lb[8]; for(int i=0;i<8;i++) lb[i]=(uint8_t)(bits>>(56-i*8)); sha1_update(s,lb,8);
+        for(int i=0;i<5;i++){ out[i*4]=s->h[i]>>24; out[i*4+1]=s->h[i]>>16; out[i*4+2]=s->h[i]>>8; out[i*4+3]=s->h[i]; }
+}
+
+// ---------------- HMAC-SHA1 -------------------------------------------------
+static void hmac_sha1(const uint8_t *key, size_t keylen, const uint8_t *msg, size_t msglen, uint8_t out[20]){
+        uint8_t k[64]; memset(k,0,64);
+        if (keylen>64){ sha1_t t; sha1_init(&t); sha1_update(&t,key,keylen); sha1_final(&t,k); }
+        else memcpy(k,key,keylen);
+        uint8_t ipad[64],opad[64];
+        for(int i=0;i<64;i++){ ipad[i]=k[i]^0x36; opad[i]=k[i]^0x5c; }
+        uint8_t inner[20];
+        sha1_t s; sha1_init(&s); sha1_update(&s,ipad,64); sha1_update(&s,msg,msglen); sha1_final(&s,inner);
+        sha1_t o; sha1_init(&o); sha1_update(&o,opad,64); sha1_update(&o,inner,20); sha1_final(&o,out);
+}
+
+// expose for tests
+
+// ---------------- AES-CM keystream ------------------------------------------
+static void aes_cm(const aes128_t *ek, const uint8_t iv[16], uint8_t *out, size_t len) {
+        uint8_t ctr[16]; memcpy(ctr, iv, 16);
+        uint8_t blk[16]; size_t off = 0;
+        while (off < len) {
+                aes128_encrypt(ek, ctr, blk);
+                size_t n = len - off; if (n > 16) n = 16;
+                memcpy(out + off, blk, n); off += n;
+                for (int b = 15; b >= 0; b--) { if (++ctr[b]) break; }
+        }
+}
+
+// AES-CM keystream XORed into data (in place).
+static void aes_cm_xor(const aes128_t *ek, const uint8_t iv[16], uint8_t *data, size_t len) {
+        uint8_t ctr[16]; memcpy(ctr, iv, 16);
+        uint8_t blk[16]; size_t off = 0;
+        while (off < len) {
+                aes128_encrypt(ek, ctr, blk);
+                size_t n = len - off; if (n > 16) n = 16;
+                for (size_t i = 0; i < n; i++) data[off + i] ^= blk[i];
+                off += n;
+                for (int b = 15; b >= 0; b--) { if (++ctr[b]) break; }
+        }
+}
+
+// SRTP key derivation (RFC 3711 4.3, key_derivation_rate = 0).
+// label: 0 = encryption, 1 = authentication, 2 = salt.
+static void srtp_kdf(const uint8_t master_key[16], const uint8_t master_salt[14],
+                     uint8_t label, uint8_t *out, size_t len) {
+        aes128_t ek; aes128_init(&ek, master_key);
+        uint8_t iv[16]; memcpy(iv, master_salt, 14); iv[14] = 0; iv[15] = 0;
+        iv[7] ^= label;
+        aes_cm(&ek, iv, out, len);
+}
+
+int homekit_srtp_init(homekit_srtp_t *ctx,
+                      const uint8_t master_key[16], const uint8_t master_salt[14],
+                      uint32_t ssrc) {
+        if (!ctx || !master_key || !master_salt) return -1;
+        uint8_t enc_key[16];
+        srtp_kdf(master_key, master_salt, 0, enc_key, 16);
+        srtp_kdf(master_key, master_salt, 1, ctx->auth_key, 20);
+        srtp_kdf(master_key, master_salt, 2, ctx->salt, 14);
+
+        aes128_t ek; aes128_init(&ek, enc_key);
+        memcpy(ctx->enc_rk, ek.rk, 176);
+        memset(enc_key, 0, sizeof(enc_key));
+
+        ctx->ssrc = ssrc;
+        ctx->roc = 0;
+        ctx->last_seq = 0;
+        ctx->seq_seen = 0;
+        return 0;
+}
+
+int homekit_srtp_protect(homekit_srtp_t *ctx, uint8_t *pkt, size_t pkt_len, size_t capacity) {
+        if (!ctx || !pkt || pkt_len < 12) return -1;
+        if (capacity < pkt_len + HOMEKIT_SRTP_AUTH_TAG_SIZE) return -2;
+
+        uint16_t seq = ((uint16_t)pkt[2] << 8) | pkt[3];
+
+        // Maintain the 32-bit rollover counter from the 16-bit sequence number.
+        if (ctx->seq_seen && seq < ctx->last_seq)
+                ctx->roc++;
+        ctx->last_seq = seq;
+        ctx->seq_seen = 1;
+
+        // AES-CM IV (RFC 3711 4.1.1):
+        //   iv = (salt||0x0000) XOR (ssrc<<64) XOR (packet_index<<16)
+        //   packet_index = ROC(32) || SEQ(16)  (48-bit)
+        uint8_t iv[16];
+        memset(iv, 0, 16);
+        iv[4] = (uint8_t)(ctx->ssrc >> 24); iv[5] = (uint8_t)(ctx->ssrc >> 16);
+        iv[6] = (uint8_t)(ctx->ssrc >> 8);  iv[7] = (uint8_t)(ctx->ssrc);
+        uint64_t index = ((uint64_t)ctx->roc << 16) | seq;
+        iv[8]  = (uint8_t)(index >> 40); iv[9]  = (uint8_t)(index >> 32);
+        iv[10] = (uint8_t)(index >> 24); iv[11] = (uint8_t)(index >> 16);
+        iv[12] = (uint8_t)(index >> 8);  iv[13] = (uint8_t)(index);
+        for (int i = 0; i < 14; i++) iv[i] ^= ctx->salt[i];
+
+        // Encrypt the payload (everything after the 12-byte header).
+        aes128_t ek; memcpy(ek.rk, ctx->enc_rk, 176);
+        aes_cm_xor(&ek, iv, pkt + 12, pkt_len - 12);
+
+        // Authenticate the whole (encrypted) packet plus the 32-bit ROC.
+        // The SRTP authenticated portion is the RTP packet followed by the ROC.
+        // Place the ROC just past the packet (there is room: capacity already
+        // reserves >= 10 bytes for the tag) to form a contiguous HMAC input,
+        // then overwrite those bytes with the 10-byte tag.
+        pkt[pkt_len + 0] = (uint8_t)(ctx->roc >> 24);
+        pkt[pkt_len + 1] = (uint8_t)(ctx->roc >> 16);
+        pkt[pkt_len + 2] = (uint8_t)(ctx->roc >> 8);
+        pkt[pkt_len + 3] = (uint8_t)(ctx->roc);
+        uint8_t tag[20];
+        hmac_sha1(ctx->auth_key, 20, pkt, pkt_len + 4, tag);
+        memcpy(pkt + pkt_len, tag, HOMEKIT_SRTP_AUTH_TAG_SIZE);
+        return (int)(pkt_len + HOMEKIT_SRTP_AUTH_TAG_SIZE);
+}

--- a/tests/host/test_srtp.c
+++ b/tests/host/test_srtp.c
@@ -1,0 +1,185 @@
+// Host tests for the SRTP sender (src/srtp.c) and the H.264 RTP packetizer
+// (src/rtp.c). Crypto primitives are checked against published vectors
+// (FIPS-197 AES, RFC 2202 HMAC-SHA1, RFC 3711 B.3 SRTP KDF); the SRTP+RTP path
+// is checked by a protect -> decrypt/verify -> NAL-reassembly round-trip.
+//
+// The .c files are #included so the test can reach the static primitives and
+// so srtp/rtp live in a single translation unit (no duplicate public symbols).
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../src/srtp.c"
+#include "../../src/rtp.c"
+
+static int eq(const void *a, const void *b, int n) { return memcmp(a, b, n) == 0; }
+static int from_hex(const char *h, uint8_t *o) {
+        int n = 0;
+        while (h[0] && h[1]) { unsigned v; sscanf(h, "%2x", &v); o[n++] = (uint8_t)v; h += 2; }
+        return n;
+}
+
+static void test_vectors(void) {
+        // AES-128 FIPS-197 known-answer
+        uint8_t k[16], pt[16], ct[16], exp[16];
+        from_hex("000102030405060708090a0b0c0d0e0f", k);
+        from_hex("00112233445566778899aabbccddeeff", pt);
+        from_hex("69c4e0d86a7b0430d8cdb78070b4c55a", exp);
+        aes128_t a; aes128_init(&a, k); aes128_encrypt(&a, pt, ct);
+        assert(eq(ct, exp, 16));
+
+        // HMAC-SHA1 RFC 2202 #1 and #2
+        uint8_t hk[20]; memset(hk, 0x0b, 20);
+        uint8_t hexp[20], hout[20];
+        from_hex("b617318655057264e28bc0b6fb378c8ef146be00", hexp);
+        hmac_sha1(hk, 20, (const uint8_t *)"Hi There", 8, hout);
+        assert(eq(hout, hexp, 20));
+        from_hex("effcdf6ae5eb2fa2d27416d5f184df9c259a7c79", hexp);
+        hmac_sha1((const uint8_t *)"Jefe", 4, (const uint8_t *)"what do ya want for nothing?", 28, hout);
+        assert(eq(hout, hexp, 20));
+
+        // SRTP KDF RFC 3711 B.3
+        uint8_t mk[16], ms[14], ek[16], ak[20], sk[14], e[20];
+        from_hex("E1F97A0D3E018BE0D64FA32C06DE4139", mk);
+        from_hex("0EC675AD498AFEEBB6960B3AABE6", ms);
+        srtp_kdf(mk, ms, 0, ek, 16); from_hex("C61E7A93744F39EE10734AFE3FF7A087", e); assert(eq(ek, e, 16));
+        srtp_kdf(mk, ms, 1, ak, 20); from_hex("CEBE321F6FF7716B6FD4AB49AF256A156D38BAA4", e); assert(eq(ak, e, 20));
+        srtp_kdf(mk, ms, 2, sk, 14); from_hex("30CBBC08863D8C85D49DB34A9AE1", e); assert(eq(sk, e, 14));
+}
+
+// Independent SRTP "unprotect" for the test: verify tag, decrypt payload.
+static int srtp_unprotect(const uint8_t *mk, const uint8_t *ms, uint32_t ssrc,
+                          uint8_t *pkt, size_t len, uint32_t roc) {
+        if (len < 12 + HOMEKIT_SRTP_AUTH_TAG_SIZE) return -1;
+        uint8_t enc[16], auth[20], salt[14];
+        srtp_kdf(mk, ms, 0, enc, 16);
+        srtp_kdf(mk, ms, 1, auth, 20);
+        srtp_kdf(mk, ms, 2, salt, 14);
+        size_t body = len - HOMEKIT_SRTP_AUTH_TAG_SIZE;
+        // verify tag over body || roc
+        uint8_t tmp[2048];
+        assert(body + 4 <= sizeof(tmp));
+        memcpy(tmp, pkt, body);
+        tmp[body] = roc >> 24; tmp[body+1] = roc >> 16; tmp[body+2] = roc >> 8; tmp[body+3] = roc;
+        uint8_t tag[20]; hmac_sha1(auth, 20, tmp, body + 4, tag);
+        if (!eq(tag, pkt + body, HOMEKIT_SRTP_AUTH_TAG_SIZE)) return -2;
+        // decrypt payload (bytes 12..body)
+        uint16_t seq = (pkt[2] << 8) | pkt[3];
+        uint8_t iv[16]; memset(iv, 0, 16);
+        iv[4]=ssrc>>24; iv[5]=ssrc>>16; iv[6]=ssrc>>8; iv[7]=ssrc;
+        uint64_t idx = ((uint64_t)roc << 16) | seq;
+        iv[8]=idx>>40; iv[9]=idx>>32; iv[10]=idx>>24; iv[11]=idx>>16; iv[12]=idx>>8; iv[13]=idx;
+        for (int i = 0; i < 14; i++) iv[i] ^= salt[i];
+        aes128_t a; aes128_init(&a, enc);
+        aes_cm_xor(&a, iv, pkt + 12, body - 12);
+        return (int)body;
+}
+
+static void test_srtp_roundtrip(void) {
+        uint8_t mk[16], ms[14];
+        for (int i = 0; i < 16; i++) mk[i] = (uint8_t)(i * 3 + 1);
+        for (int i = 0; i < 14; i++) ms[i] = (uint8_t)(i * 5 + 2);
+        homekit_srtp_t ctx; assert(homekit_srtp_init(&ctx, mk, ms, 0xDEADBEEF) == 0);
+
+        uint8_t pkt[256], orig[256];
+        memset(pkt, 0, sizeof(pkt));
+        pkt[0]=0x80; pkt[1]=99; pkt[2]=0; pkt[3]=0;  // seq 0
+        pkt[8]=0xDE; pkt[9]=0xAD; pkt[10]=0xBE; pkt[11]=0xEF;
+        for (int i = 0; i < 40; i++) pkt[12+i] = (uint8_t)(i ^ 0x5a);
+        size_t plen = 12 + 40;
+        memcpy(orig, pkt, plen);
+
+        int n = homekit_srtp_protect(&ctx, pkt, plen, sizeof(pkt));
+        assert(n == (int)plen + HOMEKIT_SRTP_AUTH_TAG_SIZE);
+        assert(!eq(pkt + 12, orig + 12, 40));  // payload encrypted
+
+        int b = srtp_unprotect(mk, ms, 0xDEADBEEF, pkt, n, 0);
+        assert(b == (int)plen);
+        assert(eq(pkt, orig, plen));           // decrypts back to original
+}
+
+// Capture sent packets for the RTP packetizer test.
+#define MAXPKTS 64
+static uint8_t cap_buf[MAXPKTS][2048];
+static size_t  cap_len[MAXPKTS];
+static int     cap_n;
+static void capture_send(void *user, const uint8_t *pkt, size_t len) {
+        (void)user; assert(cap_n < MAXPKTS); assert(len <= 2048);
+        memcpy(cap_buf[cap_n], pkt, len); cap_len[cap_n] = len; cap_n++;
+}
+
+static void test_rtp_h264(void) {
+        uint8_t mk[16], ms[14];
+        for (int i = 0; i < 16; i++) mk[i] = (uint8_t)(i + 7);
+        for (int i = 0; i < 14; i++) ms[i] = (uint8_t)(i + 11);
+
+        // Access unit: small SPS NAL + large IDR NAL (forces FU-A), Annex-B.
+        uint8_t au[4096]; size_t au_len = 0;
+        const uint8_t sc4[4] = {0,0,0,1};
+        // NAL1: type 7 (SPS), 8 bytes
+        memcpy(au+au_len, sc4, 4); au_len += 4;
+        size_t nal1_off = au_len;
+        au[au_len++] = 0x67; for (int i = 0; i < 7; i++) au[au_len++] = (uint8_t)(0x10+i);
+        size_t nal1_len = au_len - nal1_off;
+        // NAL2: type 5 (IDR), 1500 bytes
+        memcpy(au+au_len, sc4, 4); au_len += 4;
+        size_t nal2_off = au_len;
+        au[au_len++] = 0x65; for (int i = 0; i < 1499; i++) au[au_len++] = (uint8_t)(i*7+3);
+        size_t nal2_len = au_len - nal2_off;
+
+        uint8_t scratch[256];
+        homekit_rtp_h264_t rc;
+        assert(homekit_rtp_h264_init(&rc, mk, ms, 0x11223344, 99, sizeof(scratch),
+                                     scratch, capture_send, NULL) == 0);
+        cap_n = 0;
+        int sent = homekit_rtp_h264_send(&rc, au, au_len, 90000);
+        assert(sent == cap_n && sent >= 2);
+
+        // Decrypt every packet and reassemble NAL units.
+        static uint8_t reasm[8192]; size_t rlen = 0;
+        uint8_t nals[8][4096]; size_t nlens[8]; int ncount = 0;
+        uint32_t roc = 0; uint16_t prev = 0; int seen = 0;
+        for (int i = 0; i < cap_n; i++) {
+                uint8_t *p = cap_buf[i]; size_t L = cap_len[i];
+                uint16_t seq = (p[2] << 8) | p[3];
+                if (seen && seq < prev) roc++;
+                prev = seq; seen = 1;
+                int b = srtp_unprotect(mk, ms, 0x11223344, p, L, roc);
+                assert(b > 12);
+                const uint8_t *pl = p + 12; size_t pll = b - 12;
+                uint8_t t = pl[0] & 0x1f;
+                if (t == 28) { // FU-A
+                        uint8_t fu = pl[1];
+                        if (fu & 0x80) { // start
+                                rlen = 0;
+                                reasm[rlen++] = (pl[0] & 0xE0) | (fu & 0x1f); // reconstruct NAL header
+                        }
+                        memcpy(reasm + rlen, pl + 2, pll - 2); rlen += pll - 2;
+                        if (fu & 0x40) { // end
+                                memcpy(nals[ncount], reasm, rlen); nlens[ncount] = rlen; ncount++;
+                        }
+                } else { // single NAL
+                        memcpy(nals[ncount], pl, pll); nlens[ncount] = pll; ncount++;
+                }
+        }
+        assert(ncount == 2);
+        assert(nlens[0] == nal1_len && eq(nals[0], au + nal1_off, nal1_len));
+        assert(nlens[1] == nal2_len && eq(nals[1], au + nal2_off, nal2_len));
+
+        // marker bit must be set only on the final packet of the access unit.
+        for (int i = 0; i < cap_n; i++) {
+                int marker = (cap_buf[i][1] & 0x80) != 0;
+                assert(marker == (i == cap_n - 1));
+        }
+}
+
+int main(void) {
+        test_vectors();
+        test_srtp_roundtrip();
+        test_rtp_h264();
+        puts("srtp/rtp tests passed");
+        return 0;
+}


### PR DESCRIPTION
Voltooit het camera-streaming-pad met de media-plane primitieven.

## Nieuw (zelfstandig, geen externe crypto-dep, linker dropt indien ongebruikt)
- `src/srtp.c` + `include/homekit/srtp.h` — SRTP-zender (SRTP_AES_CM_128_HMAC_SHA1_80): AES-128, SHA-1, HMAC-SHA1, AES-CM key-derivation, per-pakket AES-CM-encryptie + 80-bit HMAC-tag, rollover-counter.
- `src/rtp.c` + `include/homekit/rtp.h` — H.264 RTP-packetizer (RFC 6184 single-NAL + FU-A), SRTP-beschermt elk pakket, levert via send-callback (bv. UDP).

## Validatie (host-CI, ASan/UBSan)
- AES-128 vs **FIPS-197**, HMAC-SHA1 vs **RFC 2202**, SRTP-KDF vs **RFC 3711 §B.3**.
- SRTP protect → onafhankelijke decrypt/verify round-trip.
- RTP → SRTP-decrypt → NAL-herassemblage (incl. FU-A) round-trip + marker-bit-checks.

## Eerlijk over scope
Geverifieerd: de SRTP-crypto (tegen gepubliceerde vectoren) en de RTP/FU-A-framing (round-trip). Niet zonder hardware te verifiëren: capture/encode-loop (esp_video/esp_h264), UDP-transport, RTCP, en de exacte SRTP-sleutelrichting — die staan als on-device bring-up in `docs/CAMERA.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)